### PR TITLE
stop ignoring license.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Dockerfile
 deployment.yaml
 my*.yaml
 *.txt
+!LICENSE.txt

--- a/tools/maven/LICENSE.txt
+++ b/tools/maven/LICENSE.txt
@@ -1,0 +1,17 @@
+^/\*$
+^ \* Licensed to the Apache Software Foundation \(ASF\) under one$
+^ \* or more contributor license agreements\.  See the NOTICE file$
+^ \* distributed with this work for additional information$
+^ \* regarding copyright ownership\.  The ASF licenses this file$
+^ \* to you under the Apache License, Version 2\.0 \(the$
+^ \* "License"\); you may not use this file except in compliance$
+^ \* with the License\.  You may obtain a copy of the License at$
+^ \*$
+^ \*     http://www\.apache\.org/licenses/LICENSE-2\.0$
+^ \*$
+^ \* Unless required by applicable law or agreed to in writing, software$
+^ \* distributed under the License is distributed on an "AS IS" BASIS,$
+^ \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.$
+^ \* See the License for the specific language governing permissions and$
+^ \* limitations under the License\.$
+^ \*/$


### PR DESCRIPTION
Fix gitignore to not ignore the LICENSE.txt

> It's a good idea to open an issue first for discussion.

- [x ] Tests pass
- [ x] Appropriate changes to documentation are included in the PR
