### PR TITLE
Revert "Bump com.puppycrawl.tools:checkstyle from 8.14 to 8.29"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@ under the License.
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
                         <!-- Note: match version with docs/flinkDev/ide_setup.md -->
-                        <version>8.29</version>
+                        <version>8.14</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
Reverts google/flink-connector-gcp#15

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.1.2:check (validate) on project flink-examples-gcp: Failed during checkstyle configuration: cannot initialize module TreeWalker - cannot initialize module JavadocMethod - Property 'allowUndeclaredRTE' does not exist, please check the documentation -> [Help 1]
version needs to be < 8.24