### PR TITLE
Explicitly declared the unshaded guava version.

### DIFF
--- a/flink-examples-gcp/pom.xml
+++ b/flink-examples-gcp/pom.xml
@@ -119,6 +119,11 @@ under the License.
         <artifactId>flink-avro</artifactId>
         <version>1.13.6</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.1.3-jre</version>
+    </dependency>
  </dependencies>
 
 


### PR DESCRIPTION
Flink BQ connector transitively introduced an unshaded guava dependency that got excluded from their shaded package. This results in Maven resolving the unshaded guava in this repo randomly. The explicit declaration makes sure that the unshaded guava resolved when packaging this jar is the correct transitive dependency.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
