### PR TITLE
Merge shuffle changes and remove fixed retry.

### DIFF
--- a/flink-examples-gcp/src/main/java/flink/connector/gcp/GCStoGCSUnboundedWC.java
+++ b/flink-examples-gcp/src/main/java/flink/connector/gcp/GCStoGCSUnboundedWC.java
@@ -78,7 +78,6 @@ public class GCStoGCSUnboundedWC {
         config.set(CheckpointingOptions.CHECKPOINT_STORAGE, "filesystem");
         config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
         env.configure(config);
-        env.disableOperatorChaining();
         env.enableCheckpointing(10000L);
         env.getCheckpointConfig().enableUnalignedCheckpoints();
         env.getCheckpointConfig().setAlignedCheckpointTimeout(Duration.ofMillis(10000L));


### PR DESCRIPTION
Add shuffle-stage input argument to configure the number of shuffle stages.
Remove the fixed-retry strategy to avoid job failures during TM timeout.
