### PR TITLE
update kafka and BQ connector dependencies

### DIFF
--- a/flink-examples-gcp/pom.xml
+++ b/flink-examples-gcp/pom.xml
@@ -35,7 +35,7 @@ under the License.
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <flink.version>1.19.0</flink.version>
-    <kafka.connector.version>3.1-SNAPSHOT</kafka.connector.version>
+    <kafka.connector.version>3.1.0-1.17</kafka.connector.version>
     <flink-connector-bigquery.version>0.2.0</flink-connector-bigquery.version>
   </properties>
 


### PR DESCRIPTION
compile kafka connector from maven instead of locally built snapshot

upgrade bq connector to 0.3.0
