### PR TITLE
remove GMK_PASSWORD env var from kafka cli yaml definition

### DIFF
--- a/tools/kafka/kafka-cli.yaml
+++ b/tools/kafka/kafka-cli.yaml
@@ -10,10 +10,4 @@ spec:
     image: <IMAGE>
     command: ["/bin/sh"]
     args: ["-c", "./entrypoint.sh; while true; do sleep 3600; done"]
-    env:
-      - name: GMK_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            key: password
-            name: gmk-sasl-plain-login
   restartPolicy: OnFailure


### PR DESCRIPTION
we dont deploy the gmk-sasl-plain-login k8s secret on clusters anymore. removing so that it is not required for deploying the kafka cli 