### PR TITLE
Add RowData Serializer

### DIFF
--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordToRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordToRowMutationSerializer.java
@@ -79,6 +79,12 @@ public class GenericRecordToRowMutationSerializer
 
     @Override
     public RowMutationEntry serialize(GenericRecord record, SinkWriter.Context context) {
+        if (record.getSchema().getField(rowKeyField).schema().getType() != Schema.Type.STRING) {
+            throw new RuntimeException(
+                    ErrorMessages.ROW_KEY_STRING_TYPE
+                            + record.getSchema().getField(rowKeyField).schema().getType());
+        }
+
         RowMutationEntry entry = RowMutationEntry.create((String) record.get(rowKeyField));
 
         if (!useNestedRowsMode) {
@@ -144,6 +150,8 @@ public class GenericRecordToRowMutationSerializer
                 return ByteBuffer.allocate(Double.BYTES).putDouble((Double) obj).array();
             case BOOLEAN:
                 return ByteBuffer.allocate(Byte.BYTES).put((byte) ((Boolean) obj ? 1 : 0)).array();
+            case RECORD:
+                throw new IllegalArgumentException(ErrorMessages.NESTED_TYPE_ERROR);
             default:
                 throw new IllegalArgumentException(
                         ErrorMessages.UNSUPPORTED_SERIALIZATION_TYPE + type);

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordToRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordToRowMutationSerializer.java
@@ -33,6 +33,8 @@ import javax.annotation.Nullable;
 
 import java.nio.ByteBuffer;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A serializer that converts {@link GenericRecord} objects into Bigtable {@link RowMutationEntry}
  * objects.
@@ -191,6 +193,7 @@ public class GenericRecordToRowMutationSerializer
         }
 
         public GenericRecordToRowMutationSerializer build() {
+            checkNotNull(this.rowKeyField, ErrorMessages.ROW_KEY_FIELD_NULL);
             if (columnFamily != null && useNestedRowsMode) {
                 throw new IllegalArgumentException(
                         ErrorMessages.COLUMN_FAMILY_AND_NESTED_INCOMPATIBLE);

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordToRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordToRowMutationSerializer.java
@@ -81,8 +81,9 @@ public class GenericRecordToRowMutationSerializer
     public RowMutationEntry serialize(GenericRecord record, SinkWriter.Context context) {
         if (record.getSchema().getField(rowKeyField).schema().getType() != Schema.Type.STRING) {
             throw new RuntimeException(
-                    ErrorMessages.ROW_KEY_STRING_TYPE
-                            + record.getSchema().getField(rowKeyField).schema().getType());
+                    String.format(
+                            ErrorMessages.ROW_KEY_STRING_TYPE_TEMPLATE,
+                            record.getSchema().getField(rowKeyField).schema().getType()));
         }
 
         RowMutationEntry entry = RowMutationEntry.create((String) record.get(rowKeyField));

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
@@ -1,0 +1,348 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.flink.connector.gcp.bigtable.serializers;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.api.DataTypes.Field;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.flink.connector.gcp.bigtable.utils.BigtableUtils;
+import com.google.flink.connector.gcp.bigtable.utils.ErrorMessages;
+import com.google.protobuf.ByteString;
+
+import javax.annotation.Nullable;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A serializer that converts {@link RowData} objects into Bigtable {@link RowMutationEntry}
+ * objects.
+ *
+ * <p>This serializer supports two modes of operation:
+ *
+ * <ol>
+ *   <li>**Column Family Mode:** All fields in the {@link RowData} are written to a single specified
+ *       column family. Nested fields are not supported in this mode.
+ *   <li>**Nested Rows Mode:** Each field in the {@link RowData} (except the row key field)
+ *       represents a separate column family, and its value must be another {@link RowData}
+ *       containing the columns for that family. Only single nested rows are supported.
+ * </ol>
+ *
+ * <p>The serialization process involves extracting data from the {@link RowData} fields and
+ * converting them to appropriate byte arrays for Bigtable.
+ */
+public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer<RowData> {
+    public final String columnFamily;
+    public Boolean useNestedRowsMode;
+    public String rowKeyField;
+    public Integer rowKeyIndex;
+
+    private final HashMap<String, DataType> columnTypeMap = new HashMap<String, DataType>();
+    private final HashMap<Integer, String> indexMap = new HashMap<Integer, String>();
+    private final HashMap<String, HashMap<Integer, String>> nestedIndexMap =
+            new HashMap<String, HashMap<Integer, String>>();
+
+    protected static final int MIN_DATETIME_PRECISION = 0;
+    protected static final int MAX_DATETIME_PRECISION = 6;
+
+    /**
+     * Constructs a {@code RowDataToMutationSerializer}.
+     *
+     * @param schema The {@link DataType} of the {@link RowData} to be serialized.
+     * @param rowKeyField The name of the field in the {@link RowData} that represents the Bigtable
+     *     <a href="https://cloud.google.com/bigtable/docs/schema-design#row-keys">row key</a>. It
+     *     must be of type String.
+     * @param useNestedRowsMode Whether to use nested rows mode. If {@code true}, each field in the
+     *     {@link RowData} (except the row key field) represents a separate column family.
+     *     Otherwise, all fields are written to a single column family specified by {@code
+     *     columnFamily}.
+     * @param columnFamily The name of the <a
+     *     href="https://cloud.google.com/bigtable/docs/schema-design#column-families">column
+     *     family</a> to use (only in column family mode).
+     */
+    public RowDataToRowMutationSerializer(
+            DataType schema,
+            String rowKeyField,
+            Boolean useNestedRowsMode,
+            @Nullable String columnFamily) {
+        this.columnFamily = columnFamily;
+        this.useNestedRowsMode = useNestedRowsMode;
+        this.rowKeyField = rowKeyField;
+
+        // Go through schema to generate maps
+        generateMapsFromSchema(schema, rowKeyField);
+
+        checkNotNull(
+                this.rowKeyIndex,
+                String.format(ErrorMessages.MISSING_ROW_KEY, rowKeyField, schema.toString()));
+    }
+
+    @Override
+    public RowMutationEntry serialize(RowData record, SinkWriter.Context context) {
+        RowMutationEntry entry =
+                RowMutationEntry.create(record.getString(this.rowKeyIndex).toString());
+
+        if (!useNestedRowsMode) {
+            return serializeWithColumnFamily(
+                    record, entry, this.columnFamily, this.indexMap, context);
+        }
+
+        for (int i = 0; i < record.getArity(); i++) {
+            if (i != this.rowKeyIndex) {
+                String columnFamilyName = this.indexMap.get(i);
+                RowData nestedRow =
+                        record.getRow(
+                                i, this.columnTypeMap.get(columnFamilyName).getChildren().size());
+                serializeWithColumnFamily(
+                        nestedRow,
+                        entry,
+                        columnFamilyName,
+                        this.nestedIndexMap.get(columnFamilyName),
+                        context);
+            }
+        }
+        return entry;
+    }
+
+    private RowMutationEntry serializeWithColumnFamily(
+            RowData record,
+            RowMutationEntry entry,
+            String columnFamily,
+            HashMap<Integer, String> innerMap,
+            SinkWriter.Context context) {
+        for (int i = 0; i < record.getArity(); i++) {
+            // Skip serializing the rowKey
+            Boolean isRowKey = (innerMap == this.indexMap) && (i == this.rowKeyIndex);
+            if (!isRowKey) {
+                String column = innerMap.get(i);
+                byte[] valueBytes =
+                        convertFieldToBytes(record, i, columnTypeMap.get(column).getLogicalType());
+                entry.setCell(
+                        columnFamily,
+                        ByteString.copyFromUtf8(column),
+                        BigtableUtils.getTimestamp(context),
+                        ByteString.copyFrom(valueBytes));
+            }
+        }
+        return entry;
+    }
+
+    /**
+     * Generates maps from the schema for internal use.
+     *
+     * @param schema The {@link DataType} of the {@link RowData}.
+     * @param rowKeyField The name of the row key field.
+     */
+    private void generateMapsFromSchema(DataType schema, String rowKeyField) {
+        int index = 0;
+        for (Field field : DataType.getFields(schema)) {
+            if (field.getDataType().getLogicalType().is(LogicalTypeFamily.DATETIME)) {
+                getPrecisionOr(
+                        field.getDataType().getLogicalType(),
+                        MIN_DATETIME_PRECISION,
+                        MAX_DATETIME_PRECISION);
+            }
+            columnTypeMap.put(field.getName(), field.getDataType());
+            indexMap.put(index, field.getName());
+
+            if (field.getDataType().getLogicalType().is(LogicalTypeRoot.ROW)) {
+                if (!useNestedRowsMode) {
+                    throw new IllegalArgumentException(ErrorMessages.NESTED_TYPE_ERROR);
+                }
+                int nestedIndex = 0;
+                HashMap<Integer, String> nestedIndexes = new HashMap<Integer, String>();
+                for (Field nestedField : DataType.getFields(field.getDataType())) {
+                    if (nestedField.getDataType().getLogicalType().is(LogicalTypeFamily.DATETIME)) {
+                        getPrecisionOr(
+                                nestedField.getDataType().getLogicalType(),
+                                MIN_DATETIME_PRECISION,
+                                MAX_DATETIME_PRECISION);
+                    }
+
+                    if (nestedField.getDataType().getLogicalType().is(LogicalTypeRoot.ROW)) {
+                        throw new IllegalArgumentException(ErrorMessages.NESTED_TYPE_ERROR);
+                    }
+
+                    nestedIndexes.put(nestedIndex, nestedField.getName());
+                    columnTypeMap.put(nestedField.getName(), nestedField.getDataType());
+                    nestedIndex++;
+                }
+                nestedIndexMap.put(field.getName(), nestedIndexes);
+            }
+
+            Boolean isNotRowAndNotKey =
+                    this.useNestedRowsMode
+                            && !field.getDataType().getLogicalType().is(LogicalTypeRoot.ROW)
+                            && !field.getName().equals(rowKeyField);
+            if (isNotRowAndNotKey) {
+                throw new IllegalArgumentException(ErrorMessages.BASE_NO_NESTED_TYPE + "ROW");
+            }
+
+            if (field.getName().equals(rowKeyField)) {
+                if (!field.getDataType().getLogicalType().is(LogicalTypeFamily.CHARACTER_STRING)) {
+                    throw new IllegalArgumentException(
+                            ErrorMessages.ROW_KEY_STRING_TYPE + field.getDataType());
+                }
+
+                this.rowKeyIndex = index;
+            }
+            index++;
+        }
+    }
+
+    /**
+     * Converts a field in a {@link RowData} to a byte array.
+     *
+     * @param row The {@link RowData} containing the field.
+     * @param index The index of the field in the {@link RowData}.
+     * @param type The {@link LogicalType} of the field.
+     * @return The byte array representation of the field.
+     */
+    @VisibleForTesting
+    static byte[] convertFieldToBytes(RowData row, Integer index, LogicalType type) {
+        // Use the DataType to determine the appropriate conversion
+        switch (type.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+                return row.getString(index).toBytes();
+            case BOOLEAN:
+                return ByteBuffer.allocate(1)
+                        .put(row.getBoolean(index) ? (byte) 1 : (byte) 0)
+                        .array();
+            case TINYINT:
+            case SMALLINT:
+                return ByteBuffer.allocate(Short.BYTES).putShort(row.getShort(index)).array();
+            case INTERVAL_YEAR_MONTH:
+            case INTEGER:
+                return ByteBuffer.allocate(Integer.BYTES).putInt(row.getInt(index)).array();
+            case DATE:
+            case INTERVAL_DAY_TIME:
+            case BIGINT:
+                return ByteBuffer.allocate(Long.BYTES).putLong(row.getLong(index)).array();
+            case FLOAT:
+                return ByteBuffer.allocate(Float.BYTES).putFloat(row.getFloat(index)).array();
+            case DOUBLE:
+                return ByteBuffer.allocate(Double.BYTES).putDouble(row.getDouble(index)).array();
+            case VARBINARY:
+            case BINARY:
+                return row.getBinary(index);
+            case TIMESTAMP_WITH_TIME_ZONE:
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                int tsPrecision =
+                        getPrecisionOr(type, MIN_DATETIME_PRECISION, MAX_DATETIME_PRECISION);
+                TimestampData ts = row.getTimestamp(index, tsPrecision);
+                ByteBuffer buffer =
+                        ByteBuffer.allocate(
+                                Long.BYTES + Integer.BYTES); // 8 bytes for long + 4 bytes for
+                buffer.putLong(ts.getMillisecond());
+                buffer.putInt(ts.getNanoOfMillisecond());
+                return buffer.array();
+            case TIME_WITHOUT_TIME_ZONE:
+                getPrecisionOr(type, MIN_DATETIME_PRECISION, MAX_DATETIME_PRECISION);
+                return ByteBuffer.allocate(Integer.BYTES).putInt(row.getInt(index)).array();
+            case DECIMAL:
+                DecimalType decimalType = (DecimalType) type;
+                int precision = decimalType.getPrecision();
+                int scale = decimalType.getScale();
+                return row.getDecimal(index, precision, scale).toUnscaledBytes();
+            case ROW:
+                throw new IllegalArgumentException(ErrorMessages.NESTED_TYPE_ERROR);
+            default:
+                throw new IllegalArgumentException(
+                        ErrorMessages.UNSUPPORTED_SERIALIZATION_TYPE + type.getTypeRoot());
+        }
+    }
+
+    @VisibleForTesting
+    static int getPrecisionOr(LogicalType type, int lowerBound, int upperBound) {
+        int precision = getPrecision(type);
+        if (precision < lowerBound || precision > upperBound) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            ErrorMessages.TIMESTAMP_OUTSIDE_PRECISION_TEMPLATE,
+                            type,
+                            lowerBound,
+                            upperBound,
+                            precision));
+        }
+        return precision;
+    }
+
+    /**
+     * Creates a new {@link Builder} for constructing {@code RowDataToMutationSerializer} instances.
+     *
+     * @return A new {@link Builder}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** A builder class for creating {@code RowDataToMutationSerializer} instances. */
+    public static class Builder {
+        private DataType schema;
+        private String rowKeyField;
+        private String columnFamily;
+        private Boolean useNestedRowsMode = false;
+
+        public Builder withSchema(DataType schema) {
+            this.schema = schema;
+            return this;
+        }
+
+        public Builder withRowKeyField(String rowKeyField) {
+            this.rowKeyField = rowKeyField;
+            return this;
+        }
+
+        public Builder withColumnFamily(String columnFamily) {
+            this.columnFamily = columnFamily;
+            return this;
+        }
+
+        public Builder withNestedRowsMode() {
+            useNestedRowsMode = true;
+            return this;
+        }
+
+        public RowDataToRowMutationSerializer build() {
+            if (columnFamily != null && useNestedRowsMode) {
+                throw new IllegalArgumentException(
+                        ErrorMessages.COLUMN_FAMILY_AND_NESTED_INCOMPATIBLE);
+            } else if (columnFamily == null && !useNestedRowsMode) {
+                throw new IllegalArgumentException(
+                        ErrorMessages.COLUMN_FAMILY_OR_NESTED_ROWS_REQUIRED);
+            }
+            return new RowDataToRowMutationSerializer(
+                    schema, rowKeyField, useNestedRowsMode, columnFamily);
+        }
+    }
+}

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
@@ -336,6 +336,8 @@ public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer
         }
 
         public RowDataToRowMutationSerializer build() {
+            checkNotNull(this.rowKeyField, ErrorMessages.ROW_KEY_FIELD_NULL);
+            checkNotNull(this.schema, ErrorMessages.SCHEMA_NULL);
             if (columnFamily != null && useNestedRowsMode) {
                 throw new IllegalArgumentException(
                         ErrorMessages.COLUMN_FAMILY_AND_NESTED_INCOMPATIBLE);

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
@@ -158,7 +158,7 @@ public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer
 
     /**
      * Generates maps from the schema to keep track of DataTypes and indexes. This is needed since
-     * the schema cannot be fetch from the {@link RowData}.
+     * the schema cannot be fetched from the {@link RowData}.
      *
      * @param schema The {@link DataType} of the {@link RowData}.
      * @param rowKeyField The name of the row key field.

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
@@ -156,7 +156,8 @@ public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer
     }
 
     /**
-     * Generates maps from the schema for internal use.
+     * Generates maps from the schema to keep track of DataTypes and indexes. This is needed since
+     * the schema cannot be fetch from the {@link RowData}.
      *
      * @param schema The {@link DataType} of the {@link RowData}.
      * @param rowKeyField The name of the row key field.
@@ -180,6 +181,7 @@ public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer
                 int nestedIndex = 0;
                 HashMap<Integer, String> nestedIndexes = new HashMap<Integer, String>();
                 for (Field nestedField : DataType.getFields(field.getDataType())) {
+                    // Verify precision for DATETIME types
                     if (nestedField.getDataType().getLogicalType().is(LogicalTypeFamily.DATETIME)) {
                         getPrecisionOr(
                                 nestedField.getDataType().getLogicalType(),

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
@@ -102,7 +102,8 @@ public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer
 
         checkNotNull(
                 this.rowKeyIndex,
-                String.format(ErrorMessages.MISSING_ROW_KEY, rowKeyField, schema.toString()));
+                String.format(
+                        ErrorMessages.MISSING_ROW_KEY_TEMPLATE, rowKeyField, schema.toString()));
     }
 
     @Override
@@ -169,7 +170,9 @@ public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer
             if (field.getName().equals(rowKeyField)) {
                 if (!field.getDataType().getLogicalType().is(LogicalTypeFamily.CHARACTER_STRING)) {
                     throw new IllegalArgumentException(
-                            ErrorMessages.ROW_KEY_STRING_TYPE + field.getDataType());
+                            String.format(
+                                    ErrorMessages.ROW_KEY_STRING_TYPE_TEMPLATE,
+                                    field.getDataType()));
                 }
                 this.rowKeyIndex = index;
             }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
@@ -28,9 +28,15 @@ public class ErrorMessages {
     public static final String UNSUPPORTED_SERIALIZATION_TYPE =
             "Unsupported type, use Bytes for more complex types: ";
     public static final String BASE_NO_NESTED_TYPE =
-            "Nested Rows mode require all non-key fields to be of type ";
+            "Nested Rows mode require all non-key fields to be of type %.";
+    public static final String NESTED_TYPE_ERROR =
+            "Nested rows are only supported with withNestedRowsMode and not double nested. Use Bytes for more complex types";
+    public static final String ROW_KEY_STRING_TYPE = "Row Key has to be of type String, got ";
     public static final String SERIALIZER_ERROR =
             "Error while serializing element to RowMutationEntry: ";
     public static final String METRICS_ENTRY_SERIALIZATION_WARNING =
             "Error while serializing RowMutationEntry for metrics, entry will be counted as 0 bytes. This error doesn't affect the job. Error: ";
+    public static final String TIMESTAMP_OUTSIDE_PRECISION_TEMPLATE =
+            "Unsupported precision, needs to be between %s and %s, got %s";
+    public static final String MISSING_ROW_KEY = "Row key field %s not found in schema %s";
 }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
@@ -31,12 +31,13 @@ public class ErrorMessages {
             "Nested Rows mode require all non-key fields to be of type ";
     public static final String NESTED_TYPE_ERROR =
             "Nested rows are only supported with withNestedRowsMode and not double nested. Use Bytes for more complex types";
-    public static final String ROW_KEY_STRING_TYPE = "Row Key has to be of type String, got ";
+    public static final String ROW_KEY_STRING_TYPE_TEMPLATE =
+            "Row Key has to be of type String, got %s.";
     public static final String SERIALIZER_ERROR =
             "Error while serializing element to RowMutationEntry: ";
     public static final String METRICS_ENTRY_SERIALIZATION_WARNING =
             "Error while serializing RowMutationEntry for metrics, entry will be counted as 0 bytes. This error doesn't affect the job. Error: ";
     public static final String TIMESTAMP_OUTSIDE_PRECISION_TEMPLATE =
             "Unsupported precision, needs to be between %s and %s, got %s";
-    public static final String MISSING_ROW_KEY = "Row key field %s not found in schema %s";
+    public static final String MISSING_ROW_KEY_TEMPLATE = "Row key field %s not found in schema %s";
 }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
@@ -40,4 +40,6 @@ public class ErrorMessages {
     public static final String TIMESTAMP_OUTSIDE_PRECISION_TEMPLATE =
             "Unsupported precision, needs to be between %s and %s, got %s";
     public static final String MISSING_ROW_KEY_TEMPLATE = "Row key field %s not found in schema %s";
+    public static final String ROW_KEY_FIELD_NULL = "Row key field must be set";
+    public static final String SCHEMA_NULL = "Row key field must be set";
 }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
@@ -28,7 +28,7 @@ public class ErrorMessages {
     public static final String UNSUPPORTED_SERIALIZATION_TYPE =
             "Unsupported type, use Bytes for more complex types: ";
     public static final String BASE_NO_NESTED_TYPE =
-            "Nested Rows mode require all non-key fields to be of type %.";
+            "Nested Rows mode require all non-key fields to be of type ";
     public static final String NESTED_TYPE_ERROR =
             "Nested rows are only supported with withNestedRowsMode and not double nested. Use Bytes for more complex types";
     public static final String ROW_KEY_STRING_TYPE = "Row Key has to be of type String, got ";

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordTest.java
@@ -132,7 +132,8 @@ public class GenericRecordTest {
         testRecord.put(TestingUtils.ROW_KEY_FIELD, 1234);
 
         Assertions.assertThatThrownBy(() -> serializer.serialize(testRecord, null))
-                .hasMessageContaining(ErrorMessages.ROW_KEY_STRING_TYPE);
+                .hasMessage(
+                        String.format(ErrorMessages.ROW_KEY_STRING_TYPE_TEMPLATE, Schema.Type.INT));
     }
 
     @Test

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordTest.java
@@ -115,7 +115,24 @@ public class GenericRecordTest {
         GenericRecord testRecord = getTestGenericRecordDoubleNested();
 
         Assertions.assertThatThrownBy(() -> serializer.serialize(testRecord, null))
-                .hasMessageContaining(ErrorMessages.UNSUPPORTED_SERIALIZATION_TYPE);
+                .hasMessageContaining(ErrorMessages.NESTED_TYPE_ERROR);
+    }
+
+    @Test
+    public void testRowKeyNoStringError() {
+        GenericRecordToRowMutationSerializer serializer = createTestSerializer(false);
+
+        Schema schema =
+                SchemaBuilder.record("TestBytes")
+                        .fields()
+                        .requiredInt(TestingUtils.ROW_KEY_FIELD)
+                        .endRecord();
+
+        GenericRecord testRecord = new GenericData.Record(schema);
+        testRecord.put(TestingUtils.ROW_KEY_FIELD, 1234);
+
+        Assertions.assertThatThrownBy(() -> serializer.serialize(testRecord, null))
+                .hasMessageContaining(ErrorMessages.ROW_KEY_STRING_TYPE);
     }
 
     @Test

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordTest.java
@@ -64,6 +64,17 @@ public class GenericRecordTest {
     }
 
     @Test
+    public void testNullKeySerializerInitialization() {
+        Assertions.assertThatThrownBy(
+                        () ->
+                                GenericRecordToRowMutationSerializer.builder()
+                                        .withRowKeyField(null)
+                                        .withColumnFamily(TestingUtils.COLUMN_FAMILY)
+                                        .build())
+                .hasMessage(ErrorMessages.ROW_KEY_FIELD_NULL);
+    }
+
+    @Test
     public void testColumnFamilyAndNestedIncompability() {
         Assertions.assertThatThrownBy(
                         () ->

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataTest.java
@@ -402,11 +402,7 @@ public class RowDataTest {
             case TIMESTAMP_WITH_TIME_ZONE:
             case TIMESTAMP_WITHOUT_TIME_ZONE:
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-                int tsPrecision =
-                        RowDataToRowMutationSerializer.getPrecisionOr(
-                                type,
-                                RowDataToRowMutationSerializer.MIN_DATETIME_PRECISION,
-                                RowDataToRowMutationSerializer.MAX_DATETIME_PRECISION);
+                int tsPrecision = RowDataToRowMutationSerializer.getPrecisionOr(type);
                 return row.getTimestamp(index, tsPrecision);
             case TIME_WITHOUT_TIME_ZONE:
                 int milliseconds = row.getInt(index);

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataTest.java
@@ -96,6 +96,30 @@ public class RowDataTest {
     }
 
     @Test
+    public void testNullKeySerializerInitialization() {
+        Assertions.assertThatThrownBy(
+                        () ->
+                                RowDataToRowMutationSerializer.builder()
+                                        .withRowKeyField(null)
+                                        .withColumnFamily(TestingUtils.COLUMN_FAMILY)
+                                        .withSchema(dtSchema)
+                                        .build())
+                .hasMessage(ErrorMessages.ROW_KEY_FIELD_NULL);
+    }
+
+    @Test
+    public void testNullSchemaSerializerInitialization() {
+        Assertions.assertThatThrownBy(
+                        () ->
+                                RowDataToRowMutationSerializer.builder()
+                                        .withSchema(null)
+                                        .withRowKeyField(TestingUtils.ROW_KEY_FIELD)
+                                        .withColumnFamily(TestingUtils.COLUMN_FAMILY)
+                                        .build())
+                .hasMessage(ErrorMessages.ROW_KEY_FIELD_NULL);
+    }
+
+    @Test
     public void testColumnFamilyAndNestedIncompability() {
         Assertions.assertThatThrownBy(
                         () ->
@@ -183,7 +207,7 @@ public class RowDataTest {
     }
 
     @Test
-    public void testRowKeyNoStringerror() {
+    public void testRowKeyNoStringError() {
         DataType dtIntegerKeySchema =
                 DataTypes.ROW(DataTypes.FIELD(TestingUtils.ROW_KEY_FIELD, DataTypes.INT()));
 

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataTest.java
@@ -1,0 +1,472 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.flink.connector.gcp.bigtable.serializers;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.flink.connector.gcp.bigtable.testingutils.TestingUtils;
+import com.google.flink.connector.gcp.bigtable.utils.ErrorMessages;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for the {@link GenericRecordToRowMutationSerializer} class.
+ *
+ * <p>This class verifies the functionality of the {@link RowDataToRowMutationSerializer} by testing
+ * its ability to serialize {@link RowData} objects into {@link RowMutationEntry} objects, with and
+ * without nested fields. It also includes tests for data type conversions and error handling.
+ */
+public class RowDataTest {
+    private final DataType dtSchema =
+            DataTypes.ROW(
+                    DataTypes.FIELD(TestingUtils.ROW_KEY_FIELD, DataTypes.STRING()),
+                    DataTypes.FIELD(TestingUtils.STRING_FIELD, DataTypes.STRING()),
+                    DataTypes.FIELD(TestingUtils.INTEGER_FIELD, DataTypes.INT()));
+
+    private final DataType dtNestedSchema =
+            DataTypes.ROW(
+                    DataTypes.FIELD(TestingUtils.ROW_KEY_FIELD, DataTypes.STRING()),
+                    DataTypes.FIELD(
+                            TestingUtils.NESTED_COLUMN_FAMILY_1,
+                            DataTypes.ROW(
+                                    DataTypes.FIELD(TestingUtils.STRING_FIELD, DataTypes.STRING()),
+                                    DataTypes.FIELD(TestingUtils.INTEGER_FIELD, DataTypes.INT()))),
+                    DataTypes.FIELD(
+                            TestingUtils.NESTED_COLUMN_FAMILY_2,
+                            DataTypes.ROW(
+                                    DataTypes.FIELD(
+                                            TestingUtils.STRING_FIELD_2, DataTypes.STRING()))));
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testCorrectSerializerInitialization(Boolean useNestedRowsMode) {
+        RowDataToRowMutationSerializer.Builder builder =
+                RowDataToRowMutationSerializer.builder()
+                        .withRowKeyField(TestingUtils.ROW_KEY_FIELD);
+
+        if (useNestedRowsMode) {
+            builder.withNestedRowsMode().withSchema(dtNestedSchema);
+        } else {
+            builder.withColumnFamily(TestingUtils.COLUMN_FAMILY).withSchema(dtSchema);
+        }
+        RowDataToRowMutationSerializer serializer = builder.build();
+
+        assertEquals(TestingUtils.ROW_KEY_FIELD, serializer.rowKeyField);
+        assertEquals(0, serializer.rowKeyIndex);
+        assertEquals(
+                useNestedRowsMode ? null : TestingUtils.COLUMN_FAMILY, serializer.columnFamily);
+        assertEquals(useNestedRowsMode, serializer.useNestedRowsMode);
+    }
+
+    @Test
+    public void testColumnFamilyAndNestedIncompability() {
+        Assertions.assertThatThrownBy(
+                        () ->
+                                RowDataToRowMutationSerializer.builder()
+                                        .withSchema(dtSchema)
+                                        .withRowKeyField(TestingUtils.ROW_KEY_FIELD)
+                                        .withNestedRowsMode()
+                                        .withColumnFamily(TestingUtils.COLUMN_FAMILY)
+                                        .build())
+                .hasMessageContaining(ErrorMessages.COLUMN_FAMILY_AND_NESTED_INCOMPATIBLE);
+    }
+
+    @Test
+    public void testNotColumnFamilyOrNestedRequired() {
+        Assertions.assertThatThrownBy(
+                        () ->
+                                RowDataToRowMutationSerializer.builder()
+                                        .withSchema(dtSchema)
+                                        .withRowKeyField(TestingUtils.ROW_KEY_FIELD)
+                                        .build())
+                .hasMessageContaining(ErrorMessages.COLUMN_FAMILY_OR_NESTED_ROWS_REQUIRED);
+    }
+
+    @Test
+    public void testWrongSchemaNestedRowsMode() {
+        Assertions.assertThatThrownBy(
+                        () ->
+                                RowDataToRowMutationSerializer.builder()
+                                        .withSchema(dtSchema)
+                                        .withRowKeyField(TestingUtils.ROW_KEY_FIELD)
+                                        .withNestedRowsMode()
+                                        .build())
+                .hasMessageContaining(ErrorMessages.BASE_NO_NESTED_TYPE + "ROW");
+    }
+
+    @Test
+    public void testDoubleNestedRowsError() {
+        DataType innerNest =
+                DataTypes.ROW(DataTypes.FIELD(TestingUtils.STRING_FIELD_2, DataTypes.STRING()));
+
+        DataType outerNest =
+                DataTypes.ROW(
+                        DataTypes.FIELD(TestingUtils.STRING_FIELD, DataTypes.STRING()),
+                        DataTypes.FIELD("doubleNest", innerNest));
+
+        DataType dtDoubleNestedSchema =
+                DataTypes.ROW(
+                        DataTypes.FIELD(TestingUtils.ROW_KEY_FIELD, DataTypes.STRING()),
+                        DataTypes.FIELD(TestingUtils.NESTED_COLUMN_FAMILY_1, outerNest));
+
+        Assertions.assertThatThrownBy(
+                        () ->
+                                RowDataToRowMutationSerializer.builder()
+                                        .withSchema(dtDoubleNestedSchema)
+                                        .withRowKeyField(TestingUtils.ROW_KEY_FIELD)
+                                        .withNestedRowsMode()
+                                        .build())
+                .hasMessageContaining(ErrorMessages.NESTED_TYPE_ERROR);
+    }
+
+    @Test
+    public void testTimestampPrecisionError() {
+        DataType dtTimestampSchema =
+                DataTypes.ROW(
+                        DataTypes.FIELD(TestingUtils.ROW_KEY_FIELD, DataTypes.STRING()),
+                        DataTypes.FIELD(
+                                "timestamp",
+                                DataTypes.TIMESTAMP(
+                                        RowDataToRowMutationSerializer.MAX_DATETIME_PRECISION
+                                                + 1)));
+        Assertions.assertThatThrownBy(
+                        () ->
+                                RowDataToRowMutationSerializer.builder()
+                                        .withSchema(dtTimestampSchema)
+                                        .withRowKeyField(TestingUtils.ROW_KEY_FIELD)
+                                        .withColumnFamily(TestingUtils.COLUMN_FAMILY)
+                                        .build())
+                .hasMessageContaining(
+                        String.format(
+                                ErrorMessages.TIMESTAMP_OUTSIDE_PRECISION_TEMPLATE,
+                                DataTypes.TIMESTAMP(
+                                        RowDataToRowMutationSerializer.MAX_DATETIME_PRECISION + 1),
+                                RowDataToRowMutationSerializer.MIN_DATETIME_PRECISION,
+                                RowDataToRowMutationSerializer.MAX_DATETIME_PRECISION));
+    }
+
+    @Test
+    public void testRowKeyNoStringerror() {
+        DataType dtIntegerKeySchema =
+                DataTypes.ROW(DataTypes.FIELD(TestingUtils.ROW_KEY_FIELD, DataTypes.INT()));
+
+        Assertions.assertThatThrownBy(
+                        () ->
+                                RowDataToRowMutationSerializer.builder()
+                                        .withSchema(dtIntegerKeySchema)
+                                        .withRowKeyField(TestingUtils.ROW_KEY_FIELD)
+                                        .withColumnFamily(TestingUtils.COLUMN_FAMILY)
+                                        .build())
+                .hasMessageContaining(ErrorMessages.ROW_KEY_STRING_TYPE);
+    }
+
+    @Test
+    public void testMissingRowKey() {
+        DataType dtIntegerKeySchema =
+                DataTypes.ROW(DataTypes.FIELD(TestingUtils.STRING_FIELD, DataTypes.STRING()));
+
+        Assertions.assertThatThrownBy(
+                        () ->
+                                RowDataToRowMutationSerializer.builder()
+                                        .withSchema(dtIntegerKeySchema)
+                                        .withRowKeyField(TestingUtils.ROW_KEY_FIELD)
+                                        .withColumnFamily(TestingUtils.COLUMN_FAMILY)
+                                        .build())
+                .hasMessageContaining(
+                        String.format(
+                                ErrorMessages.MISSING_ROW_KEY,
+                                TestingUtils.ROW_KEY_FIELD,
+                                dtIntegerKeySchema));
+    }
+
+    @Test
+    public void testTimeNestedPrecisionError() {
+        DataType dtTimeNestedSchema =
+                DataTypes.ROW(
+                        DataTypes.FIELD(TestingUtils.ROW_KEY_FIELD, DataTypes.STRING()),
+                        DataTypes.FIELD(
+                                TestingUtils.NESTED_COLUMN_FAMILY_1,
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(
+                                                "time",
+                                                DataTypes.TIME(
+                                                        RowDataToRowMutationSerializer
+                                                                        .MAX_DATETIME_PRECISION
+                                                                + 1)))));
+        Assertions.assertThatThrownBy(
+                        () ->
+                                RowDataToRowMutationSerializer.builder()
+                                        .withSchema(dtTimeNestedSchema)
+                                        .withRowKeyField(TestingUtils.ROW_KEY_FIELD)
+                                        .withNestedRowsMode()
+                                        .build())
+                .hasMessageContaining(
+                        String.format(
+                                ErrorMessages.TIMESTAMP_OUTSIDE_PRECISION_TEMPLATE,
+                                DataTypes.TIME(
+                                        RowDataToRowMutationSerializer.MAX_DATETIME_PRECISION + 1),
+                                RowDataToRowMutationSerializer.MIN_DATETIME_PRECISION,
+                                RowDataToRowMutationSerializer.MAX_DATETIME_PRECISION));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testRowMutationSerialization(Boolean useNestedRowsMode) {
+        RowDataToRowMutationSerializer serializer = createTestSerializer(useNestedRowsMode);
+        RowMutationEntry wantedEntry = TestingUtils.getTestRowMutationEntry(useNestedRowsMode);
+
+        RowData row = getRowData(useNestedRowsMode);
+        RowMutationEntry serializedEntry = serializer.serialize(row, null);
+        TestingUtils.assertRowMutationEntryEquality(serializedEntry, wantedEntry);
+    }
+
+    @Test
+    public void testRecordToBytes() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("stringField", DataTypes.STRING()),
+                        DataTypes.FIELD("charField", DataTypes.CHAR(10)),
+                        DataTypes.FIELD("varcharField", DataTypes.VARCHAR(50)),
+                        DataTypes.FIELD("booleanField", DataTypes.BOOLEAN()),
+                        DataTypes.FIELD("tinyintField", DataTypes.TINYINT()),
+                        DataTypes.FIELD("smallintField", DataTypes.SMALLINT()),
+                        DataTypes.FIELD("integerField", DataTypes.INT()),
+                        DataTypes.FIELD("longField", DataTypes.BIGINT()),
+                        DataTypes.FIELD("doubleField", DataTypes.DOUBLE()),
+                        DataTypes.FIELD("floatField", DataTypes.FLOAT()),
+                        DataTypes.FIELD("bytesField", DataTypes.BYTES()),
+                        DataTypes.FIELD("binaryField", DataTypes.BINARY(8)),
+                        DataTypes.FIELD(
+                                "timestampWithTimeZoneField",
+                                DataTypes.TIMESTAMP_WITH_TIME_ZONE(1)),
+                        DataTypes.FIELD("timestampWithoutTimeZoneField", DataTypes.TIMESTAMP(2)),
+                        DataTypes.FIELD(
+                                "timestampWithLocalTimeZoneField",
+                                DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)),
+                        DataTypes.FIELD(
+                                "timestampWithoutTimeZoneFieldSecondsPrecision",
+                                DataTypes.TIMESTAMP()),
+                        DataTypes.FIELD(
+                                "intervalYearMonthField",
+                                DataTypes.INTERVAL(DataTypes.YEAR(), DataTypes.MONTH())),
+                        DataTypes.FIELD(
+                                "intervalDaysTimeField",
+                                DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND())),
+                        DataTypes.FIELD("timeWithoutTimeZoneField", DataTypes.TIME(3)),
+                        DataTypes.FIELD(
+                                "timeWithoutTimeZoneFieldSecondsPrecision", DataTypes.TIME()),
+                        DataTypes.FIELD("dateField", DataTypes.DATE()),
+                        DataTypes.FIELD("decimalField", DataTypes.DECIMAL(9, 5)));
+
+        GenericRowData row = new GenericRowData(22);
+        row.setField(0, StringData.fromString("string-value")); // stringField
+        row.setField(1, StringData.fromString("char-value")); // charField
+        row.setField(2, StringData.fromString("varchar-value")); // varcharField
+        row.setField(3, true); // booleanField
+        row.setField(4, (short) 1); // tinyintField
+        row.setField(5, (short) 32767); // smallintField
+        row.setField(6, 123456789); // integerField
+        row.setField(7, 12345678987654321L); // longField
+        row.setField(8, 3.14159); // doubleField
+        row.setField(9, 1.234f); // floatField
+        row.setField(10, "testing".getBytes()); // bytesField
+        row.setField(11, ByteBuffer.allocate(8).putInt(1025).array()); // binaryField
+        row.setField(
+                12,
+                TimestampData.fromInstant(
+                        Instant.now(Clock.systemUTC()))); // timestampWithTimeZoneField
+        row.setField(13, TimestampData.fromInstant(Instant.now())); // timestampWithoutTimeZoneField
+        row.setField(
+                14,
+                TimestampData.fromLocalDateTime(
+                        LocalDateTime.of(
+                                2024, 1, 1, 12, 30, 0, 0))); // timestampWithLocalTimeZoneField
+        row.setField(
+                15,
+                TimestampData.fromLocalDateTime(
+                        LocalDateTime.of(
+                                2024, 1, 1, 12, 30, 0,
+                                15))); // timestampWithoutTimeZoneFieldSecondsPrecision
+        row.setField(16, 13); // intervalYearMonthField, represented internally as int
+        row.setField(17, 100L); // periodDays, represented internally as long
+        row.setField(18, LocalTime.of(15, 45, 30).toSecondOfDay()); // timeWithoutTimeZoneField
+        row.setField(
+                19,
+                LocalTime.of(15, 45, 0)
+                        .toSecondOfDay()); // timeWithoutTimeZoneFieldSecondsPrecision
+        row.setField(20, LocalDate.of(2024, 1, 15).toEpochDay()); // dateField
+        row.setField(21, DecimalData.fromBigDecimal(new BigDecimal("1729.92710"), 9, 5));
+
+        for (int i = 0; i < row.getArity(); i++) {
+            LogicalType type = schema.getLogicalType().getChildren().get(i);
+            byte[] convertedBytes =
+                    RowDataToRowMutationSerializer.convertFieldToBytes(row, i, type);
+            assertEquals(getObject(row, i, type), convertBytesToField(convertedBytes, type));
+        }
+    }
+
+    private RowDataToRowMutationSerializer createTestSerializer(Boolean useNestedRows) {
+        RowDataToRowMutationSerializer.Builder builder =
+                RowDataToRowMutationSerializer.builder()
+                        .withRowKeyField(TestingUtils.ROW_KEY_FIELD);
+        if (useNestedRows) {
+            builder.withNestedRowsMode().withSchema(dtNestedSchema);
+        } else {
+            builder.withColumnFamily(TestingUtils.COLUMN_FAMILY).withSchema(dtSchema);
+        }
+        return builder.build();
+    }
+
+    private static RowData getRowData(Boolean useNestedRows) {
+        GenericRowData r = new GenericRowData(3);
+        r.setField(0, StringData.fromString(TestingUtils.ROW_KEY_VALUE));
+        if (useNestedRows) {
+            GenericRowData nestedRow1 = new GenericRowData(2);
+            nestedRow1.setField(0, StringData.fromString(TestingUtils.STRING_VALUE));
+            nestedRow1.setField(1, TestingUtils.INTEGER_VALUE);
+
+            GenericRowData nestedRow2 = new GenericRowData(1);
+            nestedRow2.setField(0, StringData.fromString(TestingUtils.STRING_VALUE_2));
+
+            r.setField(1, nestedRow1);
+            r.setField(2, nestedRow2);
+        } else {
+            r.setField(1, StringData.fromString(TestingUtils.STRING_VALUE));
+            r.setField(2, TestingUtils.INTEGER_VALUE);
+        }
+        return r;
+    }
+
+    private static Object getObject(RowData row, Integer index, LogicalType type) {
+        switch (type.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+                return row.getString(index);
+            case BOOLEAN:
+                return row.getBoolean(index);
+            case TINYINT:
+            case SMALLINT:
+                return row.getShort(index);
+            case INTERVAL_YEAR_MONTH:
+            case INTEGER:
+                return row.getInt(index);
+            case INTERVAL_DAY_TIME:
+            case BIGINT:
+                return row.getLong(index);
+            case FLOAT:
+                return row.getFloat(index);
+            case DOUBLE:
+                return row.getDouble(index);
+            case VARBINARY:
+            case BINARY:
+                return row.getBinary(index);
+            case DATE:
+                return LocalDate.ofEpochDay(row.getLong(index));
+            case TIMESTAMP_WITH_TIME_ZONE:
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                int tsPrecision =
+                        RowDataToRowMutationSerializer.getPrecisionOr(
+                                type,
+                                RowDataToRowMutationSerializer.MIN_DATETIME_PRECISION,
+                                RowDataToRowMutationSerializer.MAX_DATETIME_PRECISION);
+                return row.getTimestamp(index, tsPrecision);
+            case TIME_WITHOUT_TIME_ZONE:
+                int milliseconds = row.getInt(index);
+                return LocalTime.ofNanoOfDay(
+                        milliseconds * 1_000_000L); // Assuming you want milliseconds for TIME
+            case DECIMAL:
+                DecimalType decimalType = (DecimalType) type;
+                int decimalPrecision = decimalType.getPrecision();
+                int scale = decimalType.getScale();
+                return row.getDecimal(index, decimalPrecision, scale);
+            default:
+                throw new IllegalArgumentException("Unsupported data type: " + type);
+        }
+    }
+
+    private static Object convertBytesToField(byte[] bytes, LogicalType type) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        switch (type.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+                return StringData.fromBytes(bytes);
+            case BOOLEAN:
+                return buffer.get() != 0;
+            case TINYINT:
+            case SMALLINT:
+                return buffer.getShort();
+            case INTERVAL_YEAR_MONTH:
+            case INTEGER:
+                return buffer.getInt();
+            case INTERVAL_DAY_TIME:
+            case BIGINT:
+                return buffer.getLong();
+            case FLOAT:
+                return buffer.getFloat();
+            case DOUBLE:
+                return buffer.getDouble();
+            case VARBINARY:
+            case BINARY:
+                return bytes; // No conversion needed for binary types
+            case TIMESTAMP_WITH_TIME_ZONE:
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                {
+                    long milliseconds = buffer.getLong(0);
+                    int nanos = buffer.getInt(Long.BYTES);
+                    return TimestampData.fromEpochMillis(milliseconds, nanos);
+                }
+            case TIME_WITHOUT_TIME_ZONE:
+                int milliseconds = buffer.getInt();
+                return LocalTime.ofNanoOfDay(milliseconds * 1_000_000L);
+            case DATE:
+                long daysSinceEpoch = buffer.getLong();
+                return LocalDate.ofEpochDay(daysSinceEpoch);
+            case DECIMAL:
+                DecimalType decimalType = (DecimalType) type;
+                int precision = decimalType.getPrecision();
+                int scale = decimalType.getScale();
+                return DecimalData.fromUnscaledBytes(bytes, precision, scale);
+            default:
+                throw new IllegalArgumentException("Unsupported data type: " + type);
+        }
+    }
+}

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataTest.java
@@ -194,7 +194,8 @@ public class RowDataTest {
                                         .withRowKeyField(TestingUtils.ROW_KEY_FIELD)
                                         .withColumnFamily(TestingUtils.COLUMN_FAMILY)
                                         .build())
-                .hasMessageContaining(ErrorMessages.ROW_KEY_STRING_TYPE);
+                .hasMessage(
+                        String.format(ErrorMessages.ROW_KEY_STRING_TYPE_TEMPLATE, DataTypes.INT()));
     }
 
     @Test
@@ -211,7 +212,7 @@ public class RowDataTest {
                                         .build())
                 .hasMessageContaining(
                         String.format(
-                                ErrorMessages.MISSING_ROW_KEY,
+                                ErrorMessages.MISSING_ROW_KEY_TEMPLATE,
                                 TestingUtils.ROW_KEY_FIELD,
                                 dtIntegerKeySchema));
     }

--- a/connectors/bigtable/flink-examples-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/examples/WriteGenericRecord.java
+++ b/connectors/bigtable/flink-examples-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/examples/WriteGenericRecord.java
@@ -68,7 +68,7 @@ public class WriteGenericRecord {
         String project = parameterTool.get("project");
         String table = parameterTool.get("table");
         String columnFamily = parameterTool.get("columnFamily", "flink");
-        Integer rate = parameterTool.getInt("rate", 10000);
+        Integer rate = parameterTool.getInt("rate", 100);
         String jobName = parameterTool.get("jobName", "Streaming Bigtable Write GenericRecord");
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();

--- a/connectors/bigtable/flink-examples-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/examples/WriteRowData.java
+++ b/connectors/bigtable/flink-examples-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/examples/WriteRowData.java
@@ -73,7 +73,7 @@ public class WriteRowData {
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-        GeneratorFunction<Long, Long> generatorFunction = n -> ån;
+        GeneratorFunction<Long, Long> generatorFunction = n -> n;
         DataGeneratorSource<Long> generatorSource =
                 new DataGeneratorSource<>(
                         generatorFunction,

--- a/connectors/bigtable/flink-examples-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/examples/WriteRowData.java
+++ b/connectors/bigtable/flink-examples-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/examples/WriteRowData.java
@@ -25,27 +25,29 @@ import org.apache.flink.api.connector.source.util.ratelimit.RateLimiterStrategy;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.connector.datagen.source.DataGeneratorSource;
 import org.apache.flink.connector.datagen.source.GeneratorFunction;
-import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.DataType;
 
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.flink.connector.gcp.bigtable.BigtableSink;
-import com.google.flink.connector.gcp.bigtable.serializers.GenericRecordToRowMutationSerializer;
-import org.apache.avro.Schema;
-import org.apache.avro.SchemaBuilder;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericRecord;
-
-import java.nio.ByteBuffer;
+import com.google.flink.connector.gcp.bigtable.serializers.RowDataToRowMutationSerializer;
 
 /**
  * This is an example pipeline for Apache Flink that demonstrates writing data to Google Cloud
- * Bigtable using the Bigtable connector and a {@link GenericRecordToRowMutationSerializer} with
- * Nested Rows to transform data into {@link RowMutationEntry} objects.
+ * Bigtable using the Bigtable connector and a {@link RowDataToRowMutationSerializer} to transform
+ * data into {@link RowMutationEntry} objects.
  *
  * <p>The pipeline generates a stream of Long values and uses a {@link
- * GenericRecordToRowMutationSerializer} to convert each Long value into a {@link RowMutationEntry}
- * that can be written to Bigtable.
+ * RowDataToRowMutationSerializer} to convert each Long value into a {@link RowMutationEntry} that
+ * can be written to Bigtable.
+ *
+ * <p>To run this example, you need to pass the argument {@code --columnFamily} or have an existing
+ * column family named {@code flink}.
  *
  * <p>You can run this example by passing the following command line arguments:
  *
@@ -53,24 +55,25 @@ import java.nio.ByteBuffer;
  *   --instance &lt;bigtable instance id&gt; \
  *   --project &lt;gcp project id&gt; \
  *   --table &lt;bigtable table id&gt; \
+ *   --columnFamily &lt;bigtable column family id&gt; \
  *   --rate &lt;number of rows to generate per second&gt; \
  *   --jobName &lt;job name&gt;
  * </pre>
  */
-public class WriteGenericRecordNested {
+public class WriteRowData {
 
     public static void main(String[] args) throws Exception {
         final ParameterTool parameterTool = ParameterTool.fromArgs(args);
         String instance = parameterTool.get("instance");
         String project = parameterTool.get("project");
         String table = parameterTool.get("table");
+        String columnFamily = parameterTool.get("columnFamily", "flink");
         Integer rate = parameterTool.getInt("rate", 100);
-        String jobName =
-                parameterTool.get("jobName", "Streaming Bigtable Write GenericRecord Nested");
+        String jobName = parameterTool.get("jobName", "Streaming Bigtable Write RowData");
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-        GeneratorFunction<Long, Long> generatorFunction = n -> n;
+        GeneratorFunction<Long, Long> generatorFunction = n -> ån;
         DataGeneratorSource<Long> generatorSource =
                 new DataGeneratorSource<>(
                         generatorFunction,
@@ -81,41 +84,24 @@ public class WriteGenericRecordNested {
         DataStreamSource<Long> generator =
                 env.fromSource(generatorSource, WatermarkStrategy.noWatermarks(), "Data Generator");
 
-        Schema schema =
-                SchemaBuilder.record("User")
-                        .fields()
-                        .requiredString("key")
-                        .name("family1")
-                        .type(
-                                SchemaBuilder.record("Family1")
-                                        .fields()
-                                        .requiredLong("ageLong")
-                                        .requiredDouble("ageDouble")
-                                        .requiredFloat("ageFloat")
-                                        .endRecord())
-                        .noDefault()
-                        .name("family2")
-                        .type(
-                                SchemaBuilder.record("Family2")
-                                        .fields()
-                                        .requiredBytes("textBytes")
-                                        .requiredBoolean("isActive")
-                                        .endRecord())
-                        .noDefault()
-                        .endRecord();
+        DataType dtSchema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("my-key", DataTypes.STRING()),
+                        DataTypes.FIELD("field-string", DataTypes.STRING()),
+                        DataTypes.FIELD("field-long", DataTypes.BIGINT()));
 
         generator
-                .map(new ToNestedGenericRecord(schema))
-                .returns(new GenericRecordAvroTypeInfo(schema))
+                .map(new ToRowData())
                 .sinkTo(
-                        BigtableSink.<GenericRecord>builder()
+                        BigtableSink.<RowData>builder()
                                 .setProjectId(project)
                                 .setInstanceId(instance)
                                 .setTable(table)
                                 .setSerializer(
-                                        GenericRecordToRowMutationSerializer.builder()
-                                                .withRowKeyField("key")
-                                                .withNestedRowsMode()
+                                        RowDataToRowMutationSerializer.builder()
+                                                .withRowKeyField("my-key")
+                                                .withSchema(dtSchema)
+                                                .withColumnFamily(columnFamily)
                                                 .build())
                                 .build())
                 .name("BigtableSink");
@@ -123,35 +109,16 @@ public class WriteGenericRecordNested {
         env.execute(jobName);
     }
 
-    /** Convert to GenericRecord. */
-    public static final class ToNestedGenericRecord implements MapFunction<Long, GenericRecord> {
-        Schema schema;
-
-        public ToNestedGenericRecord(Schema schema) {
-            this.schema = schema;
-        }
-
+    /** Convert to RowData. */
+    public static class ToRowData implements MapFunction<Long, RowData> {
         @Override
-        public GenericRecord map(Long l) throws Exception {
-            GenericRecord user = new GenericData.Record(schema);
-            GenericRecord family1 = new GenericData.Record(schema.getField("family1").schema());
-            GenericRecord family2 = new GenericData.Record(schema.getField("family2").schema());
-
-            // Generate a non-lexicographically-sorted unique key
+        public RowData map(Long l) throws Exception {
+            GenericRowData r = new GenericRowData(3);
             String key = String.format("%d#%d#%d#%d", l % 11, l % 101, l % 1013, l);
-
-            family1.put("ageLong", l);
-            family1.put("ageDouble", l.doubleValue());
-            family1.put("ageFloat", l.floatValue() / 3.3f);
-
-            family2.put("textBytes", ByteBuffer.wrap(key.getBytes()));
-            family2.put("isActive", l % 2 == 0);
-
-            user.put("key", key);
-            user.put("family1", family1);
-            user.put("family2", family2);
-
-            return user;
+            r.setField(0, StringData.fromString(key));
+            r.setField(1, StringData.fromString("field" + key));
+            r.setField(2, l);
+            return r;
         }
     }
 }

--- a/connectors/bigtable/flink-examples-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/examples/WriteWithFunction.java
+++ b/connectors/bigtable/flink-examples-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/examples/WriteWithFunction.java
@@ -61,7 +61,7 @@ public class WriteWithFunction {
         String instance = parameterTool.get("instance");
         String project = parameterTool.get("project");
         String table = parameterTool.get("table");
-        Integer rate = parameterTool.getInt("rate", 10000);
+        Integer rate = parameterTool.getInt("rate", 100);
         String jobName = parameterTool.get("jobName", "Streaming Bigtable Write With Function");
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();


### PR DESCRIPTION
Add RowData Serializer and examples. 

As a reminder, we cannot get the schema from a RowData element (as we do with GenericRecord), so we need the schema when initializing the Serializer and store the data types for future serialization

b/383889302
