### PR TITLE
[b/389999970] Add flow control setting

### DIFF
--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/CreateBigtableClients.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/CreateBigtableClients.java
@@ -27,11 +27,12 @@ import java.io.IOException;
 public class CreateBigtableClients {
 
     /** Creates Data client used for writing. */
-    public static BigtableDataClient createDataClient(String project, String instance)
-            throws IOException {
+    public static BigtableDataClient createDataClient(
+            String project, String instance, Boolean flowControl) throws IOException {
         BigtableDataSettings.Builder bigtableBuilder = BigtableDataSettings.newBuilder();
         bigtableBuilder.setProjectId(project).setInstanceId(instance);
         bigtableBuilder.stubSettings().setQuotaProjectId(project);
+        bigtableBuilder.setBulkMutationFlowControl(flowControl);
 
         return BigtableDataClient.create(bigtableBuilder.build());
     }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/BigtableSinkTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/BigtableSinkTest.java
@@ -24,6 +24,8 @@ import com.google.flink.connector.gcp.bigtable.testingutils.TestingUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for the {@link BigtableSink} class.
@@ -44,11 +46,33 @@ public class BigtableSinkTest {
                         .setInstanceId(TestingUtils.INSTANCE)
                         .setSerializer(serializer)
                         .setTable(TestingUtils.TABLE)
+                        .setFlowControl(true)
                         .build();
 
         assertEquals(TestingUtils.PROJECT, sink.projectId());
         assertEquals(TestingUtils.INSTANCE, sink.instanceId());
         assertEquals(TestingUtils.TABLE, sink.table());
+        assertTrue(sink.flowControl());
+        assertEquals(serializer, sink.serializer());
+    }
+
+    @Test
+    public void testCorrectDefaultBigtableSinkInitialization() {
+        FunctionRowMutationSerializer<RowMutationEntry> serializer =
+                new FunctionRowMutationSerializer<RowMutationEntry>(t -> t);
+
+        BigtableSink<RowMutationEntry> sink =
+                BigtableSink.<RowMutationEntry>builder()
+                        .setProjectId(TestingUtils.PROJECT)
+                        .setInstanceId(TestingUtils.INSTANCE)
+                        .setSerializer(serializer)
+                        .setTable(TestingUtils.TABLE)
+                        .build();
+
+        assertEquals(TestingUtils.PROJECT, sink.projectId());
+        assertEquals(TestingUtils.INSTANCE, sink.instanceId());
+        assertEquals(TestingUtils.TABLE, sink.table());
+        assertFalse(sink.flowControl());
         assertEquals(serializer, sink.serializer());
     }
 }


### PR DESCRIPTION
Fixes b/389999970 and Git Issue #74 

Adds [Flow Control](https://cloud.google.com/bigtable/docs/writes#flow-control) to Bigtable connector.

A test: 
<img width="1632" alt="Screenshot 2025-01-14 at 14 24 37" src="https://github.com/user-attachments/assets/ff61c5ce-4d27-4eed-a986-5b001662eafe" />
