### PR TITLE
feat(bigtable): Support non-String primary key types for row keys

### DIFF
--- a/connectors/bigtable/README.md
+++ b/connectors/bigtable/README.md
@@ -142,7 +142,9 @@ The connector is named `bigtable`.
 
 ### Row Key
 
-The Bigtable Flink Connector uses the primary key defined in your Flink schema as the row key for writing data to Bigtable. It must be of type `STRING` and cannot be null. Only one primary key can be used.
+The Bigtable Flink Connector uses the primary key defined in your Flink schema as the row key for writing data to Bigtable. It cannot be null and only one primary key can be used.
+
+The supported row key types are: `VARCHAR`, `CHAR`, `BIGINT`, `INT`, `SMALLINT`, and `TINYINT`. Numeric types are zero-padded to 19 digits to preserve lexicographic sort order for non-negative values.
 
 ```
 Schema schema =
@@ -151,6 +153,17 @@ Schema schema =
                 .column("stringColumn", DataTypes.STRING())
                 .column("intColumn", DataTypes.INT())
                 .primaryKey("my-key")
+                .build();
+```
+
+You can also use numeric primary keys:
+
+```
+Schema schema =
+        Schema.newBuilder()
+                .column("id", DataTypes.INT().notNull())
+                .column("stringColumn", DataTypes.STRING())
+                .primaryKey("id")
                 .build();
 ```
 

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordToRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordToRowMutationSerializer.java
@@ -84,7 +84,7 @@ public class GenericRecordToRowMutationSerializer
         if (record.getSchema().getField(rowKeyField).schema().getType() != Schema.Type.STRING) {
             throw new RuntimeException(
                     String.format(
-                            ErrorMessages.ROW_KEY_STRING_TYPE_TEMPLATE,
+                            ErrorMessages.ROW_KEY_UNSUPPORTED_TYPE_TEMPLATE,
                             record.getSchema().getField(rowKeyField).schema().getType()));
         }
 

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataToRowMutationSerializer.java
@@ -42,6 +42,7 @@ import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -66,11 +67,22 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * converting them to appropriate byte arrays for Bigtable.
  */
 public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer<RowData> {
+    /** Row key types that can be automatically converted to a String row key. */
+    public static final EnumSet<LogicalTypeRoot> SUPPORTED_ROW_KEY_TYPES =
+            EnumSet.of(
+                    LogicalTypeRoot.VARCHAR,
+                    LogicalTypeRoot.CHAR,
+                    LogicalTypeRoot.BIGINT,
+                    LogicalTypeRoot.INTEGER,
+                    LogicalTypeRoot.SMALLINT,
+                    LogicalTypeRoot.TINYINT);
+
     public final String columnFamily;
     public Boolean useNestedRowsMode;
     public String rowKeyField;
     public Integer rowKeyIndex;
     public final boolean upsertMode;
+    private LogicalTypeRoot rowKeyTypeRoot;
 
     private final HashMap<String, DataType> columnTypeMap = new HashMap<String, DataType>();
     private final HashMap<Integer, String> indexMap = new HashMap<Integer, String>();
@@ -79,6 +91,8 @@ public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer
 
     protected static final int MIN_DATETIME_PRECISION = 0;
     protected static final int MAX_DATETIME_PRECISION = 6;
+    // 19 is the number of digits in Long.MAX_VALUE.
+    protected static final String ROW_KEY_NUMERIC_FORMAT = "%019d";
 
     /**
      * Constructs a {@code RowDataToMutationSerializer}.
@@ -86,7 +100,10 @@ public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer
      * @param schema The {@link DataType} of the {@link RowData} to be serialized.
      * @param rowKeyField The name of the field in the {@link RowData} that represents the Bigtable
      *     <a href="https://cloud.google.com/bigtable/docs/schema-design#row-keys">row key</a>. It
-     *     must be of type String.
+     *     must be of type VARCHAR, CHAR, BIGINT, INTEGER, SMALLINT, or TINYINT. Numeric types are
+     *     zero-padded to 19 digits to preserve lexicographic sort order for non-negative values.
+     *     Negative values are not recommended as row keys, as their sort order is inverted
+     *     lexicographically.
      * @param useNestedRowsMode Whether to use nested rows mode. If {@code true}, each field in the
      *     {@link RowData} (except the row key field) represents a separate column family.
      *     Otherwise, all fields are written to a single column family specified by {@code
@@ -118,7 +135,7 @@ public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer
     @Override
     @Nullable
     public RowMutationEntry serialize(RowData record, SinkWriter.Context context) {
-        String rowKey = record.getString(this.rowKeyIndex).toString();
+        String rowKey = extractRowKeyAsString(record, this.rowKeyIndex, this.rowKeyTypeRoot);
 
         if (upsertMode) {
             RowKind kind = record.getRowKind();
@@ -169,6 +186,39 @@ public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer
         return entry;
     }
 
+    /**
+     * Extracts the row key field from a {@link RowData} and converts it to a String.
+     *
+     * <p>Supports VARCHAR, CHAR, BIGINT, INTEGER, SMALLINT, and TINYINT types. Numeric types are
+     * zero-padded to 19 digits (e.g., {@code 42} → {@code "0000000000000000042"}) to preserve
+     * lexicographic sort order for non-negative values, as recommended by the Bigtable schema
+     * design guide.
+     *
+     * @param record The row data containing the key field.
+     * @param index The field index of the row key.
+     * @param typeRoot The logical type root of the row key field.
+     * @return The row key as a String.
+     */
+    @VisibleForTesting
+    static String extractRowKeyAsString(RowData record, int index, LogicalTypeRoot typeRoot) {
+        switch (typeRoot) {
+            case VARCHAR:
+            case CHAR:
+                return record.getString(index).toString();
+            case BIGINT:
+                return String.format(ROW_KEY_NUMERIC_FORMAT, record.getLong(index));
+            case INTEGER:
+                return String.format(ROW_KEY_NUMERIC_FORMAT, record.getInt(index));
+            case SMALLINT:
+                return String.format(ROW_KEY_NUMERIC_FORMAT, record.getShort(index));
+            case TINYINT:
+                return String.format(ROW_KEY_NUMERIC_FORMAT, record.getByte(index));
+            default:
+                throw new IllegalArgumentException(
+                        String.format(ErrorMessages.ROW_KEY_UNSUPPORTED_TYPE_TEMPLATE, typeRoot));
+        }
+    }
+
     private RowMutationEntry serializeWithColumnFamily(
             RowData record,
             RowMutationEntry entry,
@@ -204,13 +254,15 @@ public class RowDataToRowMutationSerializer implements BaseRowMutationSerializer
         for (Field field : DataType.getFields(schema)) {
             // Check if key
             if (field.getName().equals(rowKeyField)) {
-                if (!field.getDataType().getLogicalType().is(LogicalTypeFamily.CHARACTER_STRING)) {
+                LogicalTypeRoot typeRoot = field.getDataType().getLogicalType().getTypeRoot();
+                if (!SUPPORTED_ROW_KEY_TYPES.contains(typeRoot)) {
                     throw new IllegalArgumentException(
                             String.format(
-                                    ErrorMessages.ROW_KEY_STRING_TYPE_TEMPLATE,
+                                    ErrorMessages.ROW_KEY_UNSUPPORTED_TYPE_TEMPLATE,
                                     field.getDataType()));
                 }
                 this.rowKeyIndex = index;
+                this.rowKeyTypeRoot = typeRoot;
             }
 
             // Populate maps for ROWs

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
@@ -19,13 +19,13 @@
 package com.google.flink.connector.gcp.bigtable.table;
 
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkV2Provider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.flink.connector.gcp.bigtable.BigtableSink;
@@ -38,6 +38,7 @@ import com.google.flink.connector.gcp.bigtable.utils.ErrorMessages;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.flink.connector.gcp.bigtable.serializers.RowDataToRowMutationSerializer.SUPPORTED_ROW_KEY_TYPES;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
@@ -58,15 +59,13 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
                         ErrorMessages.MULTIPLE_PRIMARY_KEYS_TEMPLATE,
                         resolvedSchema.getPrimaryKeyIndexes().length));
         int rowKeyIndex = resolvedSchema.getPrimaryKeyIndexes()[0];
+        DataType rowKeyDataType = resolvedSchema.getColumn(rowKeyIndex).get().getDataType();
+        LogicalTypeRoot rowKeyType = rowKeyDataType.getLogicalType().getTypeRoot();
         checkArgument(
-                resolvedSchema
-                        .getColumn(rowKeyIndex)
-                        .get()
-                        .getDataType()
-                        .equals(DataTypes.STRING().notNull()),
-                String.format(
-                        ErrorMessages.ROW_KEY_STRING_TYPE_TEMPLATE,
-                        resolvedSchema.getColumn(rowKeyIndex).get().getDataType()));
+                rowKeyDataType.equals(rowKeyDataType.notNull()), ErrorMessages.ROW_KEY_NULLABLE);
+        checkArgument(
+                SUPPORTED_ROW_KEY_TYPES.contains(rowKeyType),
+                String.format(ErrorMessages.ROW_KEY_UNSUPPORTED_TYPE_TEMPLATE, rowKeyDataType));
 
         this.connectorOptions = connectorOptions;
         this.resolvedSchema = resolvedSchema;

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
@@ -31,8 +31,8 @@ public class ErrorMessages {
             "Nested Rows mode require all non-key fields to be of type ";
     public static final String NESTED_TYPE_ERROR =
             "Nested rows are only supported with withNestedRowsMode and not double nested. Use Bytes for more complex types";
-    public static final String ROW_KEY_STRING_TYPE_TEMPLATE =
-            "Row Key has to be of type String, got %s.";
+    public static final String ROW_KEY_UNSUPPORTED_TYPE_TEMPLATE =
+            "Row Key has to be of type VARCHAR, CHAR, BIGINT, INTEGER, SMALLINT, or TINYINT, got %s.";
     public static final String SERIALIZER_ERROR =
             "Error while serializing element to RowMutationEntry: ";
     public static final String METRICS_ENTRY_SERIALIZATION_WARNING =
@@ -44,4 +44,5 @@ public class ErrorMessages {
     public static final String SCHEMA_NULL = "Row key field must be set";
     public static final String MULTIPLE_PRIMARY_KEYS_TEMPLATE =
             "There must be exactly one primary key, found %d.";
+    public static final String ROW_KEY_NULLABLE = "Row key column must not be nullable";
 }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/GenericRecordTest.java
@@ -144,7 +144,8 @@ public class GenericRecordTest {
 
         Assertions.assertThatThrownBy(() -> serializer.serialize(testRecord, null))
                 .hasMessage(
-                        String.format(ErrorMessages.ROW_KEY_STRING_TYPE_TEMPLATE, Schema.Type.INT));
+                        String.format(
+                                ErrorMessages.ROW_KEY_UNSUPPORTED_TYPE_TEMPLATE, Schema.Type.INT));
     }
 
     @Test

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/RowDataTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.types.RowKind;
 
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
@@ -210,19 +211,21 @@ public class RowDataTest {
     }
 
     @Test
-    public void testRowKeyNoStringError() {
-        DataType dtIntegerKeySchema =
-                DataTypes.ROW(DataTypes.FIELD(TestingUtils.ROW_KEY_FIELD, DataTypes.INT()));
+    public void testRowKeyUnsupportedTypeError() {
+        DataType dtDoubleKeySchema =
+                DataTypes.ROW(DataTypes.FIELD(TestingUtils.ROW_KEY_FIELD, DataTypes.DOUBLE()));
 
         Assertions.assertThatThrownBy(
                         () ->
                                 RowDataToRowMutationSerializer.builder()
-                                        .withSchema(dtIntegerKeySchema)
+                                        .withSchema(dtDoubleKeySchema)
                                         .withRowKeyField(TestingUtils.ROW_KEY_FIELD)
                                         .withColumnFamily(TestingUtils.COLUMN_FAMILY)
                                         .build())
                 .hasMessage(
-                        String.format(ErrorMessages.ROW_KEY_STRING_TYPE_TEMPLATE, DataTypes.INT()));
+                        String.format(
+                                ErrorMessages.ROW_KEY_UNSUPPORTED_TYPE_TEMPLATE,
+                                DataTypes.DOUBLE()));
     }
 
     @Test
@@ -563,6 +566,153 @@ public class RowDataTest {
         r.setField(1, nested1);
         r.setField(2, nested2);
         return r;
+    }
+
+    @Test
+    public void testIntegerRowKeySerialization() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("id", DataTypes.INT()),
+                        DataTypes.FIELD("value", DataTypes.STRING()));
+
+        RowDataToRowMutationSerializer serializer =
+                RowDataToRowMutationSerializer.builder()
+                        .withSchema(schema)
+                        .withRowKeyField("id")
+                        .withColumnFamily(TestingUtils.COLUMN_FAMILY)
+                        .build();
+
+        GenericRowData row = new GenericRowData(2);
+        row.setField(0, 42);
+        row.setField(1, StringData.fromString("hello"));
+
+        RowMutationEntry entry = serializer.serialize(row, null);
+        assertEquals("0000000000000000042", entry.toProto().getRowKey().toStringUtf8());
+    }
+
+    @Test
+    public void testBigintRowKeySerialization() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("id", DataTypes.BIGINT()),
+                        DataTypes.FIELD("value", DataTypes.STRING()));
+
+        RowDataToRowMutationSerializer serializer =
+                RowDataToRowMutationSerializer.builder()
+                        .withSchema(schema)
+                        .withRowKeyField("id")
+                        .withColumnFamily(TestingUtils.COLUMN_FAMILY)
+                        .build();
+
+        GenericRowData row = new GenericRowData(2);
+        row.setField(0, 9876543210L);
+        row.setField(1, StringData.fromString("world"));
+
+        RowMutationEntry entry = serializer.serialize(row, null);
+        assertEquals("0000000009876543210", entry.toProto().getRowKey().toStringUtf8());
+    }
+
+    @Test
+    public void testSmallintRowKeySerialization() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("id", DataTypes.SMALLINT()),
+                        DataTypes.FIELD("value", DataTypes.STRING()));
+
+        RowDataToRowMutationSerializer serializer =
+                RowDataToRowMutationSerializer.builder()
+                        .withSchema(schema)
+                        .withRowKeyField("id")
+                        .withColumnFamily(TestingUtils.COLUMN_FAMILY)
+                        .build();
+
+        GenericRowData row = new GenericRowData(2);
+        row.setField(0, (short) 99);
+        row.setField(1, StringData.fromString("test"));
+
+        RowMutationEntry entry = serializer.serialize(row, null);
+        assertEquals("0000000000000000099", entry.toProto().getRowKey().toStringUtf8());
+    }
+
+    @Test
+    public void testTinyintRowKeySerialization() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("id", DataTypes.TINYINT()),
+                        DataTypes.FIELD("value", DataTypes.STRING()));
+
+        RowDataToRowMutationSerializer serializer =
+                RowDataToRowMutationSerializer.builder()
+                        .withSchema(schema)
+                        .withRowKeyField("id")
+                        .withColumnFamily(TestingUtils.COLUMN_FAMILY)
+                        .build();
+
+        GenericRowData row = new GenericRowData(2);
+        row.setField(0, (byte) 7);
+        row.setField(1, StringData.fromString("test"));
+
+        RowMutationEntry entry = serializer.serialize(row, null);
+        assertEquals("0000000000000000007", entry.toProto().getRowKey().toStringUtf8());
+    }
+
+    @Test
+    public void testExtractRowKeyAsString() {
+        GenericRowData row = new GenericRowData(5);
+        row.setField(0, StringData.fromString("key1"));
+        row.setField(1, 42);
+        row.setField(2, 9876543210L);
+        row.setField(3, (short) 99);
+        row.setField(4, (byte) 7);
+
+        assertEquals(
+                "key1",
+                RowDataToRowMutationSerializer.extractRowKeyAsString(
+                        row, 0, LogicalTypeRoot.VARCHAR));
+        assertEquals(
+                "0000000000000000042",
+                RowDataToRowMutationSerializer.extractRowKeyAsString(
+                        row, 1, LogicalTypeRoot.INTEGER));
+        assertEquals(
+                "0000000009876543210",
+                RowDataToRowMutationSerializer.extractRowKeyAsString(
+                        row, 2, LogicalTypeRoot.BIGINT));
+        assertEquals(
+                "0000000000000000099",
+                RowDataToRowMutationSerializer.extractRowKeyAsString(
+                        row, 3, LogicalTypeRoot.SMALLINT));
+        assertEquals(
+                "0000000000000000007",
+                RowDataToRowMutationSerializer.extractRowKeyAsString(
+                        row, 4, LogicalTypeRoot.TINYINT));
+    }
+
+    @Test
+    public void testExtractRowKeyAsStringEdgeCases() {
+        GenericRowData row = new GenericRowData(2);
+        row.setField(0, Long.MAX_VALUE);
+        row.setField(1, 0L);
+
+        assertEquals(
+                "9223372036854775807",
+                RowDataToRowMutationSerializer.extractRowKeyAsString(
+                        row, 0, LogicalTypeRoot.BIGINT));
+        assertEquals(
+                "0000000000000000000",
+                RowDataToRowMutationSerializer.extractRowKeyAsString(
+                        row, 1, LogicalTypeRoot.BIGINT));
+    }
+
+    @Test
+    public void testExtractRowKeyAsStringUnsupportedType() {
+        GenericRowData row = new GenericRowData(1);
+        row.setField(0, 3.14);
+
+        Assertions.assertThatThrownBy(
+                        () ->
+                                RowDataToRowMutationSerializer.extractRowKeyAsString(
+                                        row, 0, LogicalTypeRoot.DOUBLE))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     private RowDataToRowMutationSerializer createTestSerializer(Boolean useNestedRows) {

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/table/BigtableTableTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/table/BigtableTableTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.utils.FactoryMocks;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.RowKind;
 
 import com.google.flink.connector.gcp.bigtable.table.config.BigtableConnectorOptions;
@@ -311,12 +312,70 @@ public class BigtableTableTest {
                                 "many-keys",
                                 Arrays.asList(
                                         TestingUtils.ROW_KEY_FIELD, TestingUtils.STRING_FIELD)),
-                        String.format(ErrorMessages.MULTIPLE_PRIMARY_KEYS_TEMPLATE, 2)),
-                Arguments.of(
-                        UniqueConstraint.primaryKey(
-                                "integer-key", Arrays.asList(TestingUtils.INTEGER_FIELD)),
+                        String.format(ErrorMessages.MULTIPLE_PRIMARY_KEYS_TEMPLATE, 2)));
+    }
+
+    @Test
+    public void testUnsupportedRowKeyType() {
+        List<Column> columns =
+                Arrays.asList(
+                        Column.physical("doubleField", DataTypes.DOUBLE().notNull()),
+                        Column.physical(TestingUtils.STRING_FIELD, DataTypes.STRING()));
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        columns,
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("pk", Arrays.asList("doubleField")));
+        Assertions.assertThatThrownBy(() -> new BigtableDynamicTableSink(schema, null))
+                .hasMessageContaining(
                         String.format(
-                                ErrorMessages.ROW_KEY_STRING_TYPE_TEMPLATE, DataTypes.INT())));
+                                ErrorMessages.ROW_KEY_UNSUPPORTED_TYPE_TEMPLATE,
+                                DataTypes.DOUBLE().notNull()));
+    }
+
+    @Test
+    public void testNullableRowKeyThrows() {
+        List<Column> columns =
+                Arrays.asList(
+                        Column.physical("id", DataTypes.BIGINT()),
+                        Column.physical(TestingUtils.STRING_FIELD, DataTypes.STRING()));
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        columns,
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("pk", Arrays.asList("id")));
+        Assertions.assertThatThrownBy(() -> new BigtableDynamicTableSink(schema, null))
+                .hasMessageContaining(ErrorMessages.ROW_KEY_NULLABLE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedRowKeyTypes")
+    public void testNonStringPrimaryKeyAccepted(String fieldName, DataType dataType) {
+        List<Column> columns =
+                Arrays.asList(
+                        Column.physical(fieldName, dataType.notNull()),
+                        Column.physical(TestingUtils.STRING_FIELD, DataTypes.STRING()));
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        columns,
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("pk", Arrays.asList(fieldName)));
+
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigtableConnectorOptions.COLUMN_FAMILY.key(), TestingUtils.COLUMN_FAMILY);
+
+        BigtableDynamicTableSink sink =
+                (BigtableDynamicTableSink) FactoryMocks.createTableSink(schema, options);
+        assertEquals(fieldName, sink.rowKeyField);
+    }
+
+    private static Stream<Arguments> supportedRowKeyTypes() {
+        return Stream.of(
+                Arguments.of("stringKey", DataTypes.STRING()),
+                Arguments.of("intKey", DataTypes.INT()),
+                Arguments.of("bigintKey", DataTypes.BIGINT()),
+                Arguments.of("smallintKey", DataTypes.SMALLINT()),
+                Arguments.of("tinyintKey", DataTypes.TINYINT()));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Relax the row key type constraint from `VARCHAR`/`CHAR`-only to also accept `BIGINT`, `INTEGER`, `SMALLINT`, and `TINYINT`
- Numeric types are zero-padded to 19 digits at serialization time to preserve lexicographic sort order for non-negative values, as recommended by the Bigtable schema design guide
- Update README and Javadoc to reflect the new supported row key types

## Motivation

The Bigtable connector currently requires the primary key (row key) to be of type `VARCHAR`/`CHAR`. This forces users whose source data has numeric primary keys (e.g., `INT`, `BIGINT`) to either:

1. Insert an explicit `CAST(id AS STRING)` in their SQL pipeline, or
2. Accept that Flink's planner will automatically insert a `SinkMaterializer` to coerce the type, adding an unnecessary materialization step to the pipeline

Both workarounds add unnecessary complexity. For example, consider a pipeline that writes product data to Bigtable where the source has a `BIGINT` primary key:

```sql
-- Source table with a BIGINT primary key
CREATE TABLE product_changes (
    product_id BIGINT PRIMARY KEY NOT ENFORCED,
    shop_id    BIGINT,
    title      STRING
) WITH (
    'connector' = 'kafka',
    ...
);

-- Sink table
CREATE TABLE products_bigtable (
    product_id BIGINT PRIMARY KEY NOT ENFORCED,
    shop_id    BIGINT,
    title      STRING
) WITH (
    'connector' = 'bigtable',
    'project'   = 'my-project',
    'instance'  = 'my-instance',
    'table'     = 'products',
    'column-family' = 'product'
);

-- Without this patch: fails because the connector rejects BIGINT PKs, forcing you to cast
-- and redefine the sink schema as STRING. The cast also causes Flink's planner to insert
-- a SinkMaterializer, like the one in picture below, adding an unnecessary materialization
-- step to the pipeline.
INSERT INTO products_bigtable
SELECT CAST(product_id AS STRING), shop_id, title
FROM product_changes;
```

<img width="1429" height="207" alt="image" src="https://github.com/user-attachments/assets/7388b45b-3536-47fa-bb97-d94dcc61caa5" />


With this patch: works directly, no cast needed

```sql
INSERT INTO products_bigtable
SELECT product_id, shop_id, title
FROM product_changes;
```

<img width="1441" height="171" alt="image" src="https://github.com/user-attachments/assets/597bf42b-1fad-4f86-b142-513f0ef161e9" />


Since Bigtable row keys are ultimately byte strings, and the conversion from numeric types to zero-padded strings is deterministic, lossless, and preserves lexicographic sort order for non-negative values, the connector should handle this natively.

## Changes

### Source

| File | Change |
|---|---|
| `BigtableDynamicTableSink.java` | Remove duplicate `SUPPORTED_ROW_KEY_TYPES`; delegate to `RowDataToRowMutationSerializer.SUPPORTED_ROW_KEY_TYPES` |
| `RowDataToRowMutationSerializer.java` | Make `SUPPORTED_ROW_KEY_TYPES` public; add `extractRowKeyAsString()` with zero-padded numeric formatting; widen type check in `generateMapsFromSchema()`; store `rowKeyTypeRoot` |
| `ErrorMessages.java` | Use correct `LogicalTypeRoot` names (`VARCHAR`, `CHAR`) instead of `STRING` in the error template |

### Tests

| File | Change |
|---|---|
| `BigtableTableTest.java` | Add `testNonStringPrimaryKeyAccepted` (parameterized for all types), `testUnsupportedRowKeyType` (DOUBLE), update `rowKeyCases` |
| `RowDataTest.java` | Add `testIntegerRowKeySerialization`, `testBigintRowKeySerialization`, `testSmallintRowKeySerialization`, `testTinyintRowKeySerialization`, `testExtractRowKeyAsString`, `testExtractRowKeyAsStringUnsupportedType` |

### Docs

| File | Change |
|---|---|
| `README.md` | Update Row Key section to list all supported types and add numeric PK example |
| `RowDataToRowMutationSerializer.java` | Update `@param rowKeyField` Javadoc |

## Backward compatibility

- Existing pipelines with `VARCHAR`/`CHAR` primary keys are completely unchanged — same code path, same validation
- No new configuration options — the feature is schema-driven
- No new dependencies

## Tophatting

- `./mvnw clean package -f connectors/bigtable/flink-connector-gcp-bigtable/pom.xml`
<img width="1107" height="105" alt="image" src="https://github.com/user-attachments/assets/b5d36e43-1498-41eb-b430-81d47f4d0a37" />
