### PR TITLE
feat(bigtable): support format-agnostic serialization via Flink's format SPI

### DIFF
--- a/connectors/bigtable/README.md
+++ b/connectors/bigtable/README.md
@@ -195,7 +195,7 @@ When a `DELETE` event is received, the delete scope depends on whether a `qualif
 
 ```
 -- Given: row_key='user1' with cells cf1:42, cf1:99
--- DELETE event for row_key='user1', shop_id=42
+-- DELETE event for row_key='user1' with data {row_key: 'user1', id: 42, title: 'T-Shirt'}
 -- Result: only cell cf1:42 is deleted (deleteCells), cf1:99 is untouched
 ```
 

--- a/connectors/bigtable/README.md
+++ b/connectors/bigtable/README.md
@@ -177,6 +177,30 @@ CREATE TABLE bigtable_sink (
 
 When `qualifier-field` is set, the specified field's value becomes the column qualifier and the full sub-row (including the qualifier field) is serialized as the cell value. When `qualifier-field` is not set, cells are stored under a default `payload` qualifier.
 
+#### Delete Behavior (upsert/all changelog modes)
+
+When a `DELETE` event is received, the delete scope depends on whether a `qualifier-field` is configured. This applies to both `FormatAwareRowMutationSerializer` and the built-in `RowDataToRowMutationSerializer` — both use the same delete semantics.
+
+**Without `qualifier-field`** — deletes the entire column family:
+
+```
+-- Given: row_key='user1' with cells cf1:payload, cf1:other_col
+-- DELETE event for row_key='user1'
+-- Result: all cells in cf1 for row_key='user1' are deleted (deleteFamily)
+```
+
+> **Note:** Without a `qualifier-field`, the connector does not have enough information to target a specific qualifier, so it deletes the entire column family. This means the `payload` cell and any other cells in the same family (including those written by other systems) will be deleted.
+
+**With `qualifier-field`** — deletes only the specific cell identified by the qualifier value:
+
+```
+-- Given: row_key='user1' with cells cf1:42, cf1:99
+-- DELETE event for row_key='user1', shop_id=42
+-- Result: only cell cf1:42 is deleted (deleteCells), cf1:99 is untouched
+```
+
+In nested-rows mode, the same logic applies per column family: families with a `<family>.qualifier-field` delete only the specific cell, while families without one delete the entire family.
+
 Without `value.format`, the connector uses its built-in byte serialization (see [Serializers](#serializers)).
 
 ## Table API
@@ -229,12 +253,25 @@ The following connector options are available:
 | `credentials-file` | Specifies the Google Cloud credentials file to use. |
 | `credentials-key` | Specifies the Google Cloud credentials key to use. |
 | `credentials-access-token` | Specifies the Google Cloud access token to use as credentials. |
+| `changelog-mode` | Changelog mode for the sink: `insert-only` (default), `upsert`, or `all`. Modes other than `insert-only` require a PRIMARY KEY. |
 | `batchSize` | The number of elements to group in a batch. |
 | `value.format` | The format for encoding cell values (e.g., `json`, `protobuf`). When set, uses Flink's format SPI instead of built-in byte serialization. |
 | `qualifier-field` | Field name to use as the Bigtable column qualifier. Requires `value.format` and `column-family`. When not set, cells are stored under a default `payload` qualifier. |
 | `<family>.qualifier-field` | Per-family qualifier field for nested-rows mode. Requires `value.format` and `use-nested-rows-mode`. When not set, cells are stored under a default `payload` qualifier. |
 
 Either `column-family` or `use-nested-rows-mode` is required. The `value.format` option is optional — when omitted, the connector uses its built-in byte serialization.
+
+#### Changelog Modes
+
+The `changelog-mode` option controls which types of change events the sink accepts:
+
+| Mode | Events | Description |
+|---|---|---|
+| `insert-only` | `INSERT` | Default. Only accepts inserts — suitable for append-only workloads. |
+| `upsert` | `INSERT`, `UPDATE_AFTER`, `DELETE` | Accepts inserts, updates, and deletes. `UPDATE_BEFORE` events are ignored. Requires a PRIMARY KEY. |
+| `all` | `INSERT`, `UPDATE_BEFORE`, `UPDATE_AFTER`, `DELETE` | Accepts all changelog events. Requires a PRIMARY KEY. |
+
+For `DELETE` events, see [Delete Behavior](#delete-behavior-upsertall-changelog-modes) for details on how deletes are applied to Bigtable.
 
 ## Exactly Once
 

--- a/connectors/bigtable/README.md
+++ b/connectors/bigtable/README.md
@@ -40,11 +40,12 @@ mvn clean install -DskipTest
 
 ## Serializers
 
-This connector comes with three built-in serializers to convert data types into Bigtable `RowMutationEntry` objects:
+This connector comes with four built-in serializers to convert data types into Bigtable `RowMutationEntry` objects:
 
 *   **`GenericRecordToRowMutationSerializer`**: For AVRO `GenericRecord` objects.
 *   **`RowDataToRowMutationSerializer`**: For Flink `RowData` objects.
 *   **`FunctionRowMutationSerializer`**: For custom serialization logic using a provided function.
+*   **`FormatAwareRowMutationSerializer`**: For format-agnostic serialization using Flink's format SPI. Used automatically when `value.format` is set in the Table API.
 
 You can create your own custom serializer inheriting from `BaseRowMutationSerializer`.
 
@@ -134,6 +135,50 @@ The [DataTypes](https://nightlies.apache.org/flink/flink-docs-release-1.19/api/j
 
 The maximum precision for time-based types is 6.
 
+### Format-Agnostic Mode (Table API)
+
+When using the Table API, you can use any Flink-compatible format (JSON, Protobuf, Avro, etc.) for encoding cell values by setting the `value.format` option. This delegates serialization to Flink's `SerializationFormatFactory` SPI, so any format on the classpath works automatically.
+
+**Flat Mode** (single column family):
+
+```
+CREATE TABLE bigtable_sink (
+  row_key STRING NOT NULL,
+  name STRING,
+  age INT,
+  PRIMARY KEY (row_key) NOT ENFORCED
+) WITH (
+  'connector' = 'bigtable',
+  'project' = 'my-project',
+  'instance' = 'my-instance',
+  'table' = 'my-table',
+  'column-family' = 'cf1',
+  'value.format' = 'protobuf'
+);
+```
+
+**Nested Rows Mode** (multiple column families):
+
+```
+CREATE TABLE bigtable_sink (
+  row_key STRING NOT NULL,
+  product ROW<shop_id BIGINT, title STRING>,
+  PRIMARY KEY (row_key) NOT ENFORCED
+) WITH (
+  'connector' = 'bigtable',
+  'project' = 'my-project',
+  'instance' = 'my-instance',
+  'table' = 'my-table',
+  'use-nested-rows-mode' = 'true',
+  'value.format' = 'protobuf',
+  'product.qualifier-field' = 'shop_id'
+);
+```
+
+When `qualifier-field` is set, the specified field's value becomes the column qualifier and the full sub-row (including the qualifier field) is serialized as the cell value. When `qualifier-field` is not set, cells are stored under a default `payload` qualifier.
+
+Without `value.format`, the connector uses its built-in byte serialization (see [Serializers](#serializers)).
+
 ## Table API
 
 This connector provides support for Flink's Table API, enabling easy and efficient data writing to Bigtable tables within your Flink Table API pipelines. 
@@ -185,8 +230,11 @@ The following connector options are available:
 | `credentials-key` | Specifies the Google Cloud credentials key to use. |
 | `credentials-access-token` | Specifies the Google Cloud access token to use as credentials. |
 | `batchSize` | The number of elements to group in a batch. |
+| `value.format` | The format for encoding cell values (e.g., `json`, `protobuf`). When set, uses Flink's format SPI instead of built-in byte serialization. |
+| `qualifier-field` | Field name to use as the Bigtable column qualifier. Requires `value.format` and `column-family`. When not set, cells are stored under a default `payload` qualifier. |
+| `<family>.qualifier-field` | Per-family qualifier field for nested-rows mode. Requires `value.format` and `use-nested-rows-mode`. When not set, cells are stored under a default `payload` qualifier. |
 
-Either `column-family` or `use-nested-rows-mode` is required.
+Either `column-family` or `use-nested-rows-mode` is required. The `value.format` option is optional — when omitted, the connector uses its built-in byte serialization.
 
 ## Exactly Once
 

--- a/connectors/bigtable/README.md
+++ b/connectors/bigtable/README.md
@@ -179,7 +179,7 @@ When `qualifier-field` is set, the specified field's value becomes the column qu
 
 #### Delete Behavior (upsert/all changelog modes)
 
-When a `DELETE` event is received, the delete scope depends on whether a `qualifier-field` is configured. This applies to both `FormatAwareRowMutationSerializer` and the built-in `RowDataToRowMutationSerializer` — both use the same delete semantics.
+When a `DELETE` event is received, the delete scope depends on whether a `qualifier-field` is configured. This applies to `FormatAwareRowMutationSerializer` (used when `value.format` is set). The built-in `RowDataToRowMutationSerializer` does not support `qualifier-field` and always deletes the entire column family.
 
 **Without `qualifier-field`** — deletes the entire column family:
 

--- a/connectors/bigtable/README.md
+++ b/connectors/bigtable/README.md
@@ -157,6 +157,18 @@ CREATE TABLE bigtable_sink (
 );
 ```
 
+> **Note:** In flat mode with `value.format`, the format serializer receives the full row including the row key field. Your format schema (Protobuf, Avro, JSON, etc.) must include the row key field. For example, a Protobuf schema for the table above would be:
+>
+> ```protobuf
+> message BigtableRow {
+>   string row_key = 1;
+>   string name = 2;
+>   int32 age = 3;
+> }
+> ```
+>
+> This enables use cases where the serialized payload needs to contain the row key (e.g., for downstream consumers that need the key for routing or deduplication).
+
 **Nested Rows Mode** (multiple column families):
 
 ```

--- a/connectors/bigtable/flink-connector-gcp-bigtable/pom.xml
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/pom.xml
@@ -148,6 +148,12 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
+      <artifactId>flink-json</artifactId>
+      <version>${flink.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
       <artifactId>flink-connector-test-utils</artifactId>
       <version>${flink.version}</version>
       <scope>test</scope>

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/BigtableSink.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/BigtableSink.java
@@ -79,6 +79,12 @@ public abstract class BigtableSink<T> implements Sink<T> {
                         credentials(),
                         batchSize());
 
+        try {
+            serializer().open(sinkInitContext.asSerializationSchemaInitializationContext());
+        } catch (Exception e) {
+            throw new IOException("Failed to initialize serializer", e);
+        }
+
         return new BigtableSinkWriter<T>(
                 new BigtableFlushableWriter(client, sinkInitContext, table()),
                 serializer(),

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializer.java
@@ -312,13 +312,19 @@ public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializ
             if (qc != null) {
                 // Qualifier-keyed: delete only the specific cell identified by qualifier value
                 int fieldIndex = e.getKey();
-                if (!record.isNullAt(fieldIndex)) {
-                    int arity = indexToArity.get(fieldIndex);
-                    RowData subRow = record.getRow(fieldIndex, arity);
-                    String qualifier =
-                            extractQualifier(subRow, qc.fieldIndex(), qc.fieldType());
-                    entry.deleteCells(family, ByteString.copyFromUtf8(qualifier));
+                if (record.isNullAt(fieldIndex)) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Cannot delete cell for family '%s': sub-row is null. "
+                                            + "When using a qualifier-field, DELETE events must "
+                                            + "contain the sub-row to identify which cell to delete.",
+                                    family));
                 }
+                int arity = indexToArity.get(fieldIndex);
+                RowData subRow = record.getRow(fieldIndex, arity);
+                String qualifier =
+                        extractQualifier(subRow, qc.fieldIndex(), qc.fieldType());
+                entry.deleteCells(family, ByteString.copyFromUtf8(qualifier));
             } else {
                 // No qualifier: delete entire column family
                 entry.deleteFamily(family);

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializer.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.flink.connector.gcp.bigtable.serializers;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.api.DataTypes.Field;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.utils.ProjectedRowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.types.RowKind;
+
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.flink.connector.gcp.bigtable.utils.BigtableUtils;
+import com.google.protobuf.ByteString;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link BaseRowMutationSerializer} implementation that delegates cell byte encoding to a
+ * format-provided {@link SerializationSchema}. One serializer is created per column family from the
+ * column family's sub-schema.
+ *
+ * <p>When a qualifier-field is configured for a column family, the field's value is used as the
+ * Bigtable column qualifier and the full sub-row is serialized as the cell value. When no
+ * qualifier-field is configured, the sub-row is stored under a single "payload" qualifier.
+ */
+public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializer<RowData> {
+
+    private static final String DEFAULT_QUALIFIER = "payload";
+
+    private final int rowKeyIndex;
+    private final LogicalTypeRoot rowKeyTypeRoot;
+    private final Map<Integer, String> indexToFamily;
+    private final Map<Integer, Integer> indexToArity;
+    private final Map<String, SerializationSchema<RowData>> familySerializers;
+    private final Map<String, QualifierConfig> qualifierConfigs;
+    private final boolean upsertMode;
+
+    // Flat-mode fields
+    private final boolean flatMode;
+    private final @Nullable String flatColumnFamily;
+    private final @Nullable SerializationSchema<RowData> flatSerializer;
+    private final @Nullable int[] flatProjection;
+    private final @Nullable QualifierConfig flatQualifierConfig;
+
+    /**
+     * Creates a serializer for flat mode (single column family). The entire row (minus row key) is
+     * serialized as a single blob. When {@code qualifierConfig} is non-null, the specified field's
+     * value is used as the column qualifier; otherwise cells are stored under the default {@code
+     * "payload"} qualifier.
+     *
+     * @param physicalDataType the physical schema of the incoming {@link RowData}
+     * @param rowKeyField the name of the field used as the Bigtable row key
+     * @param columnFamily the Bigtable column family to write to
+     * @param serializer the format-provided {@link SerializationSchema} for encoding cell values
+     * @param upsertMode whether to handle {@link RowKind#DELETE} and {@link
+     *     RowKind#UPDATE_BEFORE} events
+     * @param qualifierConfig optional qualifier field configuration, or {@code null} to use the
+     *     default {@code "payload"} qualifier
+     */
+    public static FormatAwareRowMutationSerializer forFlatMode(
+            DataType physicalDataType,
+            String rowKeyField,
+            String columnFamily,
+            SerializationSchema<RowData> serializer,
+            boolean upsertMode,
+            @Nullable QualifierConfig qualifierConfig) {
+        return new FormatAwareRowMutationSerializer(
+                physicalDataType, rowKeyField, columnFamily, serializer, upsertMode,
+                qualifierConfig);
+    }
+
+    private FormatAwareRowMutationSerializer(
+            DataType physicalDataType,
+            String rowKeyField,
+            String columnFamily,
+            SerializationSchema<RowData> serializer,
+            boolean upsertMode,
+            @Nullable QualifierConfig qualifierConfig) {
+        checkNotNull(physicalDataType, "physicalDataType must not be null");
+        checkNotNull(rowKeyField, "rowKeyField must not be null");
+        checkNotNull(columnFamily, "columnFamily must not be null");
+        checkNotNull(serializer, "serializer must not be null");
+
+        this.upsertMode = upsertMode;
+        this.flatMode = true;
+        this.flatColumnFamily = columnFamily;
+        this.flatSerializer = serializer;
+        this.familySerializers = Collections.emptyMap();
+        this.qualifierConfigs = Collections.emptyMap();
+        this.indexToFamily = Collections.emptyMap();
+        this.indexToArity = Collections.emptyMap();
+
+        // Resolve row key index and build projection array
+        int resolvedRowKeyIndex = -1;
+        LogicalTypeRoot resolvedRowKeyTypeRoot = null;
+        List<Integer> projection = new ArrayList<>();
+        int index = 0;
+        for (Field field : DataType.getFields(physicalDataType)) {
+            if (field.getName().equals(rowKeyField)) {
+                resolvedRowKeyIndex = index;
+                resolvedRowKeyTypeRoot = field.getDataType().getLogicalType().getTypeRoot();
+            } else {
+                projection.add(index);
+            }
+            index++;
+        }
+        checkArgument(
+                resolvedRowKeyIndex >= 0,
+                String.format("Row key field '%s' not found in schema", rowKeyField));
+        this.rowKeyIndex = resolvedRowKeyIndex;
+        this.rowKeyTypeRoot = resolvedRowKeyTypeRoot;
+        this.flatProjection = projection.stream().mapToInt(Integer::intValue).toArray();
+        this.flatQualifierConfig = qualifierConfig;
+    }
+
+    /**
+     * Creates a serializer for nested-rows mode (multiple column families). Each top-level field
+     * (except the row key) maps to a Bigtable column family. The field's sub-row is serialized
+     * using the corresponding family serializer.
+     *
+     * @param physicalDataType the physical schema of the incoming {@link RowData}
+     * @param rowKeyField the name of the field used as the Bigtable row key
+     * @param familySerializers a map from column family name to its {@link SerializationSchema}
+     * @param qualifierConfigs a map from column family name to its {@link QualifierConfig}, for
+     *     families that use a field value as the column qualifier. Families not present in this map
+     *     use the default {@code "payload"} qualifier.
+     * @param upsertMode whether to handle {@link RowKind#DELETE} and {@link
+     *     RowKind#UPDATE_BEFORE} events
+     */
+    public FormatAwareRowMutationSerializer(
+            DataType physicalDataType,
+            String rowKeyField,
+            Map<String, SerializationSchema<RowData>> familySerializers,
+            Map<String, QualifierConfig> qualifierConfigs,
+            boolean upsertMode) {
+        checkNotNull(physicalDataType, "physicalDataType must not be null");
+        checkNotNull(rowKeyField, "rowKeyField must not be null");
+        checkNotNull(familySerializers, "familySerializers must not be null");
+        checkNotNull(qualifierConfigs, "qualifierConfigs must not be null");
+
+        this.upsertMode = upsertMode;
+        this.familySerializers = familySerializers;
+        this.qualifierConfigs = qualifierConfigs;
+        this.indexToFamily = new HashMap<>();
+        this.indexToArity = new HashMap<>();
+
+        int resolvedRowKeyIndex = -1;
+        LogicalTypeRoot resolvedRowKeyTypeRoot = null;
+        int index = 0;
+        for (Field field : DataType.getFields(physicalDataType)) {
+            if (field.getName().equals(rowKeyField)) {
+                resolvedRowKeyIndex = index;
+                resolvedRowKeyTypeRoot = field.getDataType().getLogicalType().getTypeRoot();
+            } else {
+                indexToFamily.put(index, field.getName());
+                indexToArity.put(index, DataType.getFields(field.getDataType()).size());
+            }
+            index++;
+        }
+        checkArgument(
+                resolvedRowKeyIndex >= 0,
+                String.format("Row key field '%s' not found in schema", rowKeyField));
+        this.rowKeyIndex = resolvedRowKeyIndex;
+        this.rowKeyTypeRoot = resolvedRowKeyTypeRoot;
+
+        this.flatMode = false;
+        this.flatColumnFamily = null;
+        this.flatSerializer = null;
+        this.flatProjection = null;
+        this.flatQualifierConfig = null;
+    }
+
+    @Override
+    public void open(SerializationSchema.InitializationContext context) throws Exception {
+        if (flatMode && flatSerializer != null) {
+            flatSerializer.open(context);
+        }
+        for (SerializationSchema<RowData> serializer : familySerializers.values()) {
+            serializer.open(context);
+        }
+    }
+
+    @Override
+    @Nullable
+    public RowMutationEntry serialize(RowData record, SinkWriter.Context context) {
+        if (upsertMode) {
+            RowKind kind = record.getRowKind();
+            if (kind == RowKind.UPDATE_BEFORE) {
+                return null;
+            }
+            if (kind == RowKind.DELETE) {
+                return serializeDelete(record);
+            }
+        }
+
+        String rowKey =
+                RowDataToRowMutationSerializer.extractRowKeyAsString(
+                        record, rowKeyIndex, rowKeyTypeRoot);
+        RowMutationEntry entry = RowMutationEntry.create(rowKey);
+
+        if (flatMode) {
+            // Flat mode: project out row key, serialize entire projected row as one blob
+            ProjectedRowData projected = ProjectedRowData.from(flatProjection);
+            projected.replaceRow(record);
+            byte[] value = flatSerializer.serialize(projected);
+            String qualifier =
+                    flatQualifierConfig != null
+                            ? extractQualifier(
+                                    projected,
+                                    flatQualifierConfig.fieldIndex(),
+                                    flatQualifierConfig.fieldType())
+                            : DEFAULT_QUALIFIER;
+            entry.setCell(
+                    flatColumnFamily,
+                    ByteString.copyFromUtf8(qualifier),
+                    BigtableUtils.getTimestamp(context),
+                    ByteString.copyFrom(value));
+            return entry;
+        }
+
+        // Nested mode
+        for (int i = 0; i < record.getArity(); i++) {
+            if (i == rowKeyIndex) {
+                continue;
+            }
+            if (record.isNullAt(i)) {
+                continue;
+            }
+
+            String family = indexToFamily.get(i);
+            int arity = indexToArity.get(i);
+            RowData subRow = record.getRow(i, arity);
+            SerializationSchema<RowData> serializer = familySerializers.get(family);
+
+            QualifierConfig qc = qualifierConfigs.get(family);
+            if (qc != null) {
+                String qualifier = extractQualifier(subRow, qc.fieldIndex(), qc.fieldType());
+                byte[] value = serializer.serialize(subRow);
+                entry.setCell(
+                        family,
+                        ByteString.copyFromUtf8(qualifier),
+                        BigtableUtils.getTimestamp(context),
+                        ByteString.copyFrom(value));
+            } else {
+                byte[] value = serializer.serialize(subRow);
+                entry.setCell(
+                        family,
+                        ByteString.copyFromUtf8(DEFAULT_QUALIFIER),
+                        BigtableUtils.getTimestamp(context),
+                        ByteString.copyFrom(value));
+            }
+        }
+        return entry;
+    }
+
+    private RowMutationEntry serializeDelete(RowData record) {
+        String rowKey =
+                RowDataToRowMutationSerializer.extractRowKeyAsString(
+                        record, rowKeyIndex, rowKeyTypeRoot);
+        RowMutationEntry entry = RowMutationEntry.create(rowKey);
+
+        if (flatMode) {
+            if (flatQualifierConfig != null) {
+                ProjectedRowData projected = ProjectedRowData.from(flatProjection);
+                projected.replaceRow(record);
+                String qualifier =
+                        extractQualifier(
+                                projected,
+                                flatQualifierConfig.fieldIndex(),
+                                flatQualifierConfig.fieldType());
+                entry.deleteCells(flatColumnFamily, ByteString.copyFromUtf8(qualifier));
+            } else {
+                entry.deleteFamily(flatColumnFamily);
+            }
+            return entry;
+        }
+
+        // Nested mode: delete each column family
+        for (Map.Entry<Integer, String> e : indexToFamily.entrySet()) {
+            String family = e.getValue();
+            QualifierConfig qc = qualifierConfigs.get(family);
+            if (qc != null) {
+                // Qualifier-keyed: delete only the specific cell identified by qualifier value
+                int fieldIndex = e.getKey();
+                if (!record.isNullAt(fieldIndex)) {
+                    int arity = indexToArity.get(fieldIndex);
+                    RowData subRow = record.getRow(fieldIndex, arity);
+                    String qualifier =
+                            extractQualifier(subRow, qc.fieldIndex(), qc.fieldType());
+                    entry.deleteCells(family, ByteString.copyFromUtf8(qualifier));
+                }
+            } else {
+                // No qualifier: delete entire column family
+                entry.deleteFamily(family);
+            }
+        }
+        return entry;
+    }
+
+    private static String extractQualifier(RowData row, int fieldIndex, LogicalType type) {
+        if (row.isNullAt(fieldIndex)) {
+            throw new IllegalArgumentException(
+                    "Qualifier field at index " + fieldIndex + " must not be null");
+        }
+        if (type.is(LogicalTypeFamily.CHARACTER_STRING)) {
+            return row.getString(fieldIndex).toString();
+        } else if (type.is(LogicalTypeFamily.INTEGER_NUMERIC)) {
+            switch (type.getTypeRoot()) {
+                case TINYINT:
+                    return String.valueOf(row.getByte(fieldIndex));
+                case SMALLINT:
+                    return String.valueOf(row.getShort(fieldIndex));
+                case INTEGER:
+                    return String.valueOf(row.getInt(fieldIndex));
+                case BIGINT:
+                    return String.valueOf(row.getLong(fieldIndex));
+                default:
+                    throw new IllegalArgumentException(
+                            "Unsupported qualifier field type: " + type.getTypeRoot());
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "Qualifier field must be a string or integer type, got: " + type);
+        }
+    }
+}

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializer.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.table.api.DataTypes.Field;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.utils.ProjectedRowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
@@ -35,10 +34,8 @@ import com.google.protobuf.ByteString;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -69,7 +66,6 @@ public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializ
     private final boolean flatMode;
     private final @Nullable String flatColumnFamily;
     private final @Nullable SerializationSchema<RowData> flatSerializer;
-    private final @Nullable int[] flatProjection;
     private final @Nullable QualifierConfig flatQualifierConfig;
 
     /**
@@ -120,17 +116,14 @@ public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializ
         this.indexToFamily = Collections.emptyMap();
         this.indexToArity = Collections.emptyMap();
 
-        // Resolve row key index and build projection array
+        // Resolve row key index
         int resolvedRowKeyIndex = -1;
         LogicalTypeRoot resolvedRowKeyTypeRoot = null;
-        List<Integer> projection = new ArrayList<>();
         int index = 0;
         for (Field field : DataType.getFields(physicalDataType)) {
             if (field.getName().equals(rowKeyField)) {
                 resolvedRowKeyIndex = index;
                 resolvedRowKeyTypeRoot = field.getDataType().getLogicalType().getTypeRoot();
-            } else {
-                projection.add(index);
             }
             index++;
         }
@@ -139,7 +132,6 @@ public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializ
                 String.format("Row key field '%s' not found in schema", rowKeyField));
         this.rowKeyIndex = resolvedRowKeyIndex;
         this.rowKeyTypeRoot = resolvedRowKeyTypeRoot;
-        this.flatProjection = projection.stream().mapToInt(Integer::intValue).toArray();
         this.flatQualifierConfig = qualifierConfig;
     }
 
@@ -196,7 +188,6 @@ public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializ
         this.flatMode = false;
         this.flatColumnFamily = null;
         this.flatSerializer = null;
-        this.flatProjection = null;
         this.flatQualifierConfig = null;
     }
 
@@ -229,14 +220,12 @@ public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializ
         RowMutationEntry entry = RowMutationEntry.create(rowKey);
 
         if (flatMode) {
-            // Flat mode: project out row key, serialize entire projected row as one blob
-            ProjectedRowData projected = ProjectedRowData.from(flatProjection);
-            projected.replaceRow(record);
-            byte[] value = flatSerializer.serialize(projected);
+            // Flat mode: serialize entire row (including row key) as one blob
+            byte[] value = flatSerializer.serialize(record);
             String qualifier =
                     flatQualifierConfig != null
                             ? extractQualifier(
-                                    projected,
+                                    record,
                                     flatQualifierConfig.fieldIndex(),
                                     flatQualifierConfig.fieldType())
                             : DEFAULT_QUALIFIER;
@@ -291,11 +280,9 @@ public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializ
 
         if (flatMode) {
             if (flatQualifierConfig != null) {
-                ProjectedRowData projected = ProjectedRowData.from(flatProjection);
-                projected.replaceRow(record);
                 String qualifier =
                         extractQualifier(
-                                projected,
+                                record,
                                 flatQualifierConfig.fieldIndex(),
                                 flatQualifierConfig.fieldType());
                 entry.deleteCells(flatColumnFamily, ByteString.copyFromUtf8(qualifier));

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializer.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializer.java
@@ -78,8 +78,8 @@ public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializ
      * @param rowKeyField the name of the field used as the Bigtable row key
      * @param columnFamily the Bigtable column family to write to
      * @param serializer the format-provided {@link SerializationSchema} for encoding cell values
-     * @param upsertMode whether to handle {@link RowKind#DELETE} and {@link
-     *     RowKind#UPDATE_BEFORE} events
+     * @param upsertMode whether to handle {@link RowKind#DELETE} and {@link RowKind#UPDATE_BEFORE}
+     *     events
      * @param qualifierConfig optional qualifier field configuration, or {@code null} to use the
      *     default {@code "payload"} qualifier
      */
@@ -91,7 +91,11 @@ public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializ
             boolean upsertMode,
             @Nullable QualifierConfig qualifierConfig) {
         return new FormatAwareRowMutationSerializer(
-                physicalDataType, rowKeyField, columnFamily, serializer, upsertMode,
+                physicalDataType,
+                rowKeyField,
+                columnFamily,
+                serializer,
+                upsertMode,
                 qualifierConfig);
     }
 
@@ -146,8 +150,8 @@ public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializ
      * @param qualifierConfigs a map from column family name to its {@link QualifierConfig}, for
      *     families that use a field value as the column qualifier. Families not present in this map
      *     use the default {@code "payload"} qualifier.
-     * @param upsertMode whether to handle {@link RowKind#DELETE} and {@link
-     *     RowKind#UPDATE_BEFORE} events
+     * @param upsertMode whether to handle {@link RowKind#DELETE} and {@link RowKind#UPDATE_BEFORE}
+     *     events
      */
     public FormatAwareRowMutationSerializer(
             DataType physicalDataType,
@@ -309,8 +313,7 @@ public class FormatAwareRowMutationSerializer implements BaseRowMutationSerializ
                 }
                 int arity = indexToArity.get(fieldIndex);
                 RowData subRow = record.getRow(fieldIndex, arity);
-                String qualifier =
-                        extractQualifier(subRow, qc.fieldIndex(), qc.fieldType());
+                String qualifier = extractQualifier(subRow, qc.fieldIndex(), qc.fieldType());
                 entry.deleteCells(family, ByteString.copyFromUtf8(qualifier));
             } else {
                 // No qualifier: delete entire column family

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/QualifierConfig.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/serializers/QualifierConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.flink.connector.gcp.bigtable.serializers;
+
+import org.apache.flink.table.types.logical.LogicalType;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Configuration for a qualifier-keyed column family. Holds the index and logical type of the field
+ * within the column family's sub-row that serves as the Bigtable column qualifier.
+ */
+public final class QualifierConfig implements Serializable {
+
+    private final int fieldIndex;
+    private final LogicalType fieldType;
+
+    public QualifierConfig(int fieldIndex, LogicalType fieldType) {
+        this.fieldIndex = fieldIndex;
+        this.fieldType = fieldType;
+    }
+
+    public int fieldIndex() {
+        return fieldIndex;
+    }
+
+    public LogicalType fieldType() {
+        return fieldType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QualifierConfig that = (QualifierConfig) o;
+        return fieldIndex == that.fieldIndex && Objects.equals(fieldType, that.fieldType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldIndex, fieldType);
+    }
+
+    @Override
+    public String toString() {
+        return "QualifierConfig[fieldIndex=" + fieldIndex + ", fieldType=" + fieldType + "]";
+    }
+}

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableFactory.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableFactory.java
@@ -95,12 +95,8 @@ public class BigtableDynamicTableFactory implements DynamicTableSinkFactory {
                         .filter(k -> k.endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX))
                         .map(
                                 k ->
-                                        k.substring(
-                                                        0,
-                                                        k.length()
-                                                                - BigtableConnectorOptions
-                                                                        .QUALIFIER_FIELD_SUFFIX
-                                                                        .length())
+                                        BigtableConnectorOptions
+                                                        .getFamilyFromQualifierOptionKey(k)
                                                 + ".")
                         .collect(Collectors.toSet());
 

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableFactory.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableFactory.java
@@ -19,18 +19,24 @@
 package com.google.flink.connector.gcp.bigtable.table;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.SerializationFormatFactory;
 
 import com.google.flink.connector.gcp.bigtable.table.config.BigtableChangelogMode;
 import com.google.flink.connector.gcp.bigtable.table.config.BigtableConnectorOptions;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Factory class to create configured instances of {@link BigtableDynamicTableSink}. */
 @Internal
@@ -66,6 +72,8 @@ public class BigtableDynamicTableFactory implements DynamicTableSinkFactory {
         additionalOptions.add(BigtableConnectorOptions.CREDENTIALS_KEY);
         additionalOptions.add(BigtableConnectorOptions.CREDENTIALS_ACCESS_TOKEN);
         additionalOptions.add(BigtableConnectorOptions.CHANGELOG_MODE);
+        additionalOptions.add(BigtableConnectorOptions.VALUE_FORMAT);
+        additionalOptions.add(BigtableConnectorOptions.QUALIFIER_FIELD);
 
         return additionalOptions;
     }
@@ -75,7 +83,32 @@ public class BigtableDynamicTableFactory implements DynamicTableSinkFactory {
         final FactoryUtil.TableFactoryHelper helper =
                 FactoryUtil.createTableFactoryHelper(this, context);
 
-        helper.validate();
+        final Optional<EncodingFormat<SerializationSchema<RowData>>> valueEncodingFormat =
+                helper.discoverOptionalEncodingFormat(
+                        SerializationFormatFactory.class, BigtableConnectorOptions.VALUE_FORMAT);
+
+        // Collect prefixes for dynamic qualifier-field options (e.g. "nested2.qualifier-field"
+        // has prefix "nested2."). validateExcept uses startsWith matching, so we extract the
+        // prefix portion of each qualifier-field key.
+        Set<String> qualifierFieldPrefixes =
+                context.getCatalogTable().getOptions().keySet().stream()
+                        .filter(k -> k.endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX))
+                        .map(
+                                k ->
+                                        k.substring(
+                                                        0,
+                                                        k.length()
+                                                                - BigtableConnectorOptions
+                                                                        .QUALIFIER_FIELD_SUFFIX
+                                                                        .length())
+                                                + ".")
+                        .collect(Collectors.toSet());
+
+        if (qualifierFieldPrefixes.isEmpty()) {
+            helper.validate();
+        } else {
+            helper.validateExcept(qualifierFieldPrefixes.toArray(new String[0]));
+        }
 
         final ReadableConfig tableOptions = helper.getOptions();
         final String changelogMode = tableOptions.get(BigtableConnectorOptions.CHANGELOG_MODE);
@@ -83,7 +116,10 @@ public class BigtableDynamicTableFactory implements DynamicTableSinkFactory {
         validateChangelogMode(changelogMode, context);
 
         return new BigtableDynamicTableSink(
-                context.getCatalogTable().getResolvedSchema(), tableOptions);
+                context.getCatalogTable().getResolvedSchema(),
+                tableOptions,
+                valueEncodingFormat.orElse(null),
+                context.getCatalogTable().getOptions());
     }
 
     private static void validateChangelogMode(String changelogMode, Context context) {

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableFactory.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableFactory.java
@@ -93,11 +93,7 @@ public class BigtableDynamicTableFactory implements DynamicTableSinkFactory {
         Set<String> qualifierFieldPrefixes =
                 context.getCatalogTable().getOptions().keySet().stream()
                         .filter(k -> k.endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX))
-                        .map(
-                                k ->
-                                        BigtableConnectorOptions
-                                                        .getFamilyFromQualifierOptionKey(k)
-                                                + ".")
+                        .map(k -> BigtableConnectorOptions.getFamilyFromQualifierOptionKey(k) + ".")
                         .collect(Collectors.toSet());
 
         if (qualifierFieldPrefixes.isEmpty()) {

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
@@ -119,8 +119,7 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
                     .filter(k -> k.endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX)
                             && !k.equals(BigtableConnectorOptions.QUALIFIER_FIELD.key()))
                     .forEach(k -> {
-                        String family = k.substring(
-                                0, k.length() - BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX.length());
+                        String family = BigtableConnectorOptions.getFamilyFromQualifierOptionKey(k);
                         checkArgument(
                                 schemaColumnNames.contains(family),
                                 String.format(
@@ -348,12 +347,8 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
         for (Map.Entry<String, String> entry : rawOptions.entrySet()) {
             if (entry.getKey().endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX)) {
                 String family =
-                        entry.getKey()
-                                .substring(
-                                        0,
-                                        entry.getKey().length()
-                                                - BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX
-                                                        .length());
+                        BigtableConnectorOptions.getFamilyFromQualifierOptionKey(
+                                entry.getKey());
                 String qualifierFieldName = entry.getValue();
                 configs.put(
                         family, resolveQualifierField(physicalSchema, family, qualifierFieldName));

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
@@ -20,7 +20,6 @@ package com.google.flink.connector.gcp.bigtable.table;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.DataTypes.Field;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
@@ -44,7 +43,6 @@ import com.google.flink.connector.gcp.bigtable.utils.ErrorMessages;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -226,9 +224,8 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
             } else {
                 // Flat mode: single column family, entire row as one blob
                 String columnFamily = connectorOptions.get(BigtableConnectorOptions.COLUMN_FAMILY);
-                DataType projectedType = projectWithoutRowKey(physicalSchema, rowKeyField);
                 SerializationSchema<RowData> formatSerializer =
-                        valueEncodingFormat.createRuntimeEncoder(context, projectedType);
+                        valueEncodingFormat.createRuntimeEncoder(context, physicalSchema);
                 String qualifierFieldName =
                         connectorOptions
                                 .getOptional(BigtableConnectorOptions.QUALIFIER_FIELD)
@@ -236,7 +233,7 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
                 QualifierConfig qualifierConfig =
                         qualifierFieldName != null
                                 ? resolveTopLevelQualifierField(
-                                        physicalSchema, rowKeyField, qualifierFieldName)
+                                        physicalSchema, qualifierFieldName)
                                 : null;
                 serializer =
                         FormatAwareRowMutationSerializer.forFlatMode(
@@ -358,34 +355,17 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
     }
 
     /**
-     * Creates a projected DataType that excludes the row key field. Used for flat-mode format
-     * serialization.
-     */
-    private static DataType projectWithoutRowKey(DataType physicalSchema, String rowKeyField) {
-        java.util.List<DataTypes.Field> fields = new ArrayList<>();
-        for (Field field : DataType.getFields(physicalSchema)) {
-            if (!field.getName().equals(rowKeyField)) {
-                fields.add(DataTypes.FIELD(field.getName(), field.getDataType()));
-            }
-        }
-        return DataTypes.ROW(fields.toArray(new DataTypes.Field[0]));
-    }
-
-    /**
      * Resolves the index and type of a qualifier field within a flat (non-nested) schema. The index
-     * is adjusted to account for the row key field being excluded from the projected row.
+     * matches the field's actual position in the full physical schema.
      */
     private static QualifierConfig resolveTopLevelQualifierField(
-            DataType physicalSchema, String rowKeyField, String qualifierFieldName) {
-        int adjustedIdx = 0;
+            DataType physicalSchema, String qualifierFieldName) {
+        int idx = 0;
         for (Field field : DataType.getFields(physicalSchema)) {
-            if (field.getName().equals(rowKeyField)) {
-                continue;
-            }
             if (field.getName().equals(qualifierFieldName)) {
-                return new QualifierConfig(adjustedIdx, field.getDataType().getLogicalType());
+                return new QualifierConfig(idx, field.getDataType().getLogicalType());
             }
-            adjustedIdx++;
+            idx++;
         }
         throw new IllegalArgumentException(
                 String.format("Qualifier field '%s' not found in schema", qualifierFieldName));

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
@@ -151,6 +151,9 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
                     fieldExists,
                     String.format(
                             "Qualifier field '%s' not found in schema", qualifierFieldName));
+            checkArgument(
+                    !qualifierFieldName.equals(rowKeyField),
+                    "qualifier-field cannot be the same as the primary key field");
         }
     }
 

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
@@ -18,9 +18,13 @@
 
 package com.google.flink.connector.gcp.bigtable.table;
 
+import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.DataTypes.Field;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkV2Provider;
 import org.apache.flink.table.data.RowData;
@@ -29,14 +33,25 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.flink.connector.gcp.bigtable.BigtableSink;
+import com.google.flink.connector.gcp.bigtable.serializers.BaseRowMutationSerializer;
+import com.google.flink.connector.gcp.bigtable.serializers.FormatAwareRowMutationSerializer;
+import com.google.flink.connector.gcp.bigtable.serializers.QualifierConfig;
 import com.google.flink.connector.gcp.bigtable.serializers.RowDataToRowMutationSerializer;
 import com.google.flink.connector.gcp.bigtable.table.config.BigtableChangelogMode;
 import com.google.flink.connector.gcp.bigtable.table.config.BigtableConnectorOptions;
 import com.google.flink.connector.gcp.bigtable.utils.CredentialsFactory;
 import com.google.flink.connector.gcp.bigtable.utils.ErrorMessages;
 
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.flink.connector.gcp.bigtable.serializers.RowDataToRowMutationSerializer.SUPPORTED_ROW_KEY_TYPES;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -50,9 +65,19 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
     protected final ReadableConfig connectorOptions;
     protected final ResolvedSchema resolvedSchema;
     protected final String rowKeyField;
+    protected final @Nullable EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat;
+    protected final Map<String, String> rawTableOptions;
 
     public BigtableDynamicTableSink(
             ResolvedSchema resolvedSchema, ReadableConfig connectorOptions) {
+        this(resolvedSchema, connectorOptions, null, Collections.emptyMap());
+    }
+
+    public BigtableDynamicTableSink(
+            ResolvedSchema resolvedSchema,
+            ReadableConfig connectorOptions,
+            @Nullable EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat,
+            Map<String, String> rawTableOptions) {
         checkArgument(
                 resolvedSchema.getPrimaryKeyIndexes().length == 1,
                 String.format(
@@ -71,11 +96,71 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
         this.resolvedSchema = resolvedSchema;
         this.parallelism = connectorOptions.get(BigtableConnectorOptions.SINK_PARALLELISM);
         this.rowKeyField = resolvedSchema.getColumn(rowKeyIndex).get().getName();
+        this.valueEncodingFormat = valueEncodingFormat;
+        this.rawTableOptions = rawTableOptions != null ? rawTableOptions : Collections.emptyMap();
+
+        boolean hasPrefixedQualifierFields =
+                this.rawTableOptions.keySet().stream()
+                        .anyMatch(
+                                k ->
+                                        k.endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX)
+                                                && !k.equals(BigtableConnectorOptions.QUALIFIER_FIELD.key()));
+        if (hasPrefixedQualifierFields) {
+            checkArgument(
+                    valueEncodingFormat != null, ErrorMessages.QUALIFIER_FIELD_REQUIRES_FORMAT);
+            checkArgument(
+                    connectorOptions.get(BigtableConnectorOptions.USE_NESTED_ROWS_MODE),
+                    ErrorMessages.QUALIFIER_FIELD_REQUIRES_NESTED_ROWS);
+            Set<String> schemaColumnNames =
+                    resolvedSchema.getColumns().stream()
+                            .map(c -> c.getName())
+                            .collect(Collectors.toSet());
+            this.rawTableOptions.keySet().stream()
+                    .filter(k -> k.endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX)
+                            && !k.equals(BigtableConnectorOptions.QUALIFIER_FIELD.key()))
+                    .forEach(k -> {
+                        String family = k.substring(
+                                0, k.length() - BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX.length());
+                        checkArgument(
+                                schemaColumnNames.contains(family),
+                                String.format(
+                                        "Qualifier-field family '%s' not found in schema", family));
+                    });
+        }
+
+        boolean hasTopLevelQualifierField =
+                connectorOptions
+                        .getOptional(BigtableConnectorOptions.QUALIFIER_FIELD)
+                        .isPresent();
+        if (hasTopLevelQualifierField) {
+            checkArgument(
+                    valueEncodingFormat != null, ErrorMessages.QUALIFIER_FIELD_REQUIRES_FORMAT);
+            checkArgument(
+                    connectorOptions.getOptional(BigtableConnectorOptions.COLUMN_FAMILY).isPresent(),
+                    "qualifier-field requires column-family to be set");
+            checkArgument(
+                    !connectorOptions.get(BigtableConnectorOptions.USE_NESTED_ROWS_MODE),
+                    "qualifier-field is incompatible with use-nested-rows-mode=true. "
+                            + "Use '<family>.qualifier-field' for nested-rows-mode instead.");
+            String qualifierFieldName =
+                    connectorOptions.get(BigtableConnectorOptions.QUALIFIER_FIELD);
+            boolean fieldExists =
+                    resolvedSchema.getColumns().stream()
+                            .anyMatch(col -> col.getName().equals(qualifierFieldName));
+            checkArgument(
+                    fieldExists,
+                    String.format(
+                            "Qualifier field '%s' not found in schema", qualifierFieldName));
+        }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.resolvedSchema, this.connectorOptions);
+        return Objects.hash(
+                this.resolvedSchema,
+                this.connectorOptions,
+                this.valueEncodingFormat,
+                this.rawTableOptions);
     }
 
     @Override
@@ -83,15 +168,14 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
         BigtableDynamicTableSink other = (BigtableDynamicTableSink) obj;
         return Objects.equals(resolvedSchema, other.resolvedSchema)
-                && Objects.equals(connectorOptions, other.connectorOptions);
+                && Objects.equals(connectorOptions, other.connectorOptions)
+                && Objects.equals(valueEncodingFormat, other.valueEncodingFormat)
+                && Objects.equals(rawTableOptions, other.rawTableOptions);
     }
 
     @Override
@@ -115,21 +199,68 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
     public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
         DataType physicalSchema = resolvedSchema.toPhysicalRowDataType();
 
-        RowDataToRowMutationSerializer.Builder serializerBuilder =
-                RowDataToRowMutationSerializer.builder()
-                        .withSchema(physicalSchema)
-                        .withRowKeyField(this.rowKeyField)
-                        .withUpsertMode(
-                                BigtableChangelogMode.fromString(
-                                                connectorOptions.get(
-                                                        BigtableConnectorOptions.CHANGELOG_MODE))
-                                        != BigtableChangelogMode.INSERT_ONLY);
+        boolean upsertMode =
+                BigtableChangelogMode.fromString(
+                                connectorOptions.get(BigtableConnectorOptions.CHANGELOG_MODE))
+                        != BigtableChangelogMode.INSERT_ONLY;
 
-        if (connectorOptions.get(BigtableConnectorOptions.USE_NESTED_ROWS_MODE)) {
-            serializerBuilder.withNestedRowsMode();
+        BaseRowMutationSerializer<RowData> serializer;
+
+        if (valueEncodingFormat != null) {
+            if (connectorOptions.get(BigtableConnectorOptions.USE_NESTED_ROWS_MODE)) {
+                // Format-aware path (nested rows mode)
+                Map<String, SerializationSchema<RowData>> familySerializers =
+                        buildFamilySerializers(context, physicalSchema);
+                Map<String, QualifierConfig> qualifierConfigs =
+                        parseQualifierConfigs(rawTableOptions, physicalSchema);
+
+                serializer =
+                        new FormatAwareRowMutationSerializer(
+                                physicalSchema,
+                                rowKeyField,
+                                familySerializers,
+                                qualifierConfigs,
+                                upsertMode);
+            } else {
+                // Flat mode: single column family, entire row as one blob
+                String columnFamily = connectorOptions.get(BigtableConnectorOptions.COLUMN_FAMILY);
+                DataType projectedType = projectWithoutRowKey(physicalSchema, rowKeyField);
+                SerializationSchema<RowData> formatSerializer =
+                        valueEncodingFormat.createRuntimeEncoder(context, projectedType);
+                String qualifierFieldName =
+                        connectorOptions
+                                .getOptional(BigtableConnectorOptions.QUALIFIER_FIELD)
+                                .orElse(null);
+                QualifierConfig qualifierConfig =
+                        qualifierFieldName != null
+                                ? resolveTopLevelQualifierField(
+                                        physicalSchema, rowKeyField, qualifierFieldName)
+                                : null;
+                serializer =
+                        FormatAwareRowMutationSerializer.forFlatMode(
+                                physicalSchema,
+                                rowKeyField,
+                                columnFamily,
+                                formatSerializer,
+                                upsertMode,
+                                qualifierConfig);
+            }
         } else {
-            serializerBuilder.withColumnFamily(
-                    connectorOptions.get(BigtableConnectorOptions.COLUMN_FAMILY));
+            // Legacy path (unchanged)
+            RowDataToRowMutationSerializer.Builder serializerBuilder =
+                    RowDataToRowMutationSerializer.builder()
+                            .withSchema(physicalSchema)
+                            .withRowKeyField(this.rowKeyField)
+                            .withUpsertMode(upsertMode);
+
+            if (connectorOptions.get(BigtableConnectorOptions.USE_NESTED_ROWS_MODE)) {
+                serializerBuilder.withNestedRowsMode();
+            } else {
+                serializerBuilder.withColumnFamily(
+                        connectorOptions.get(BigtableConnectorOptions.COLUMN_FAMILY));
+            }
+
+            serializer = serializerBuilder.build();
         }
 
         BigtableSink.Builder<RowData> sinkBuilder =
@@ -138,7 +269,7 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
                         .setTable(connectorOptions.get(BigtableConnectorOptions.TABLE))
                         .setInstanceId(connectorOptions.get(BigtableConnectorOptions.INSTANCE))
                         .setFlowControl(connectorOptions.get(BigtableConnectorOptions.FLOW_CONTROL))
-                        .setSerializer(serializerBuilder.build());
+                        .setSerializer(serializer);
 
         if (connectorOptions.getOptional(BigtableConnectorOptions.APP_PROFILE_ID).isPresent()) {
             sinkBuilder.setAppProfileId(
@@ -182,6 +313,105 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
 
     @Override
     public DynamicTableSink copy() {
-        return new BigtableDynamicTableSink(resolvedSchema, connectorOptions);
+        return new BigtableDynamicTableSink(
+                resolvedSchema, connectorOptions, valueEncodingFormat, rawTableOptions);
+    }
+
+    /**
+     * Creates one SerializationSchema per column family by projecting the physical schema to each
+     * family's sub-row type.
+     */
+    private Map<String, SerializationSchema<RowData>> buildFamilySerializers(
+            Context context, DataType physicalSchema) {
+        Map<String, SerializationSchema<RowData>> result = new HashMap<>();
+        for (Field field : DataType.getFields(physicalSchema)) {
+            if (field.getName().equals(rowKeyField)) {
+                continue;
+            }
+            DataType familyType = field.getDataType();
+            result.put(
+                    field.getName(), valueEncodingFormat.createRuntimeEncoder(context, familyType));
+        }
+        return result;
+    }
+
+    /**
+     * Parses qualifier-field options from raw table options. Pattern:
+     * '&lt;family&gt;.qualifier-field' = '&lt;fieldName&gt;'
+     */
+    private static Map<String, QualifierConfig> parseQualifierConfigs(
+            Map<String, String> rawOptions, DataType physicalSchema) {
+        Map<String, QualifierConfig> configs = new HashMap<>();
+        for (Map.Entry<String, String> entry : rawOptions.entrySet()) {
+            if (entry.getKey().endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX)) {
+                String family =
+                        entry.getKey()
+                                .substring(
+                                        0,
+                                        entry.getKey().length()
+                                                - BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX
+                                                        .length());
+                String qualifierFieldName = entry.getValue();
+                configs.put(
+                        family, resolveQualifierField(physicalSchema, family, qualifierFieldName));
+            }
+        }
+        return configs;
+    }
+
+    /**
+     * Creates a projected DataType that excludes the row key field. Used for flat-mode format
+     * serialization.
+     */
+    private static DataType projectWithoutRowKey(DataType physicalSchema, String rowKeyField) {
+        java.util.List<DataTypes.Field> fields = new ArrayList<>();
+        for (Field field : DataType.getFields(physicalSchema)) {
+            if (!field.getName().equals(rowKeyField)) {
+                fields.add(DataTypes.FIELD(field.getName(), field.getDataType()));
+            }
+        }
+        return DataTypes.ROW(fields.toArray(new DataTypes.Field[0]));
+    }
+
+    /**
+     * Resolves the index and type of a qualifier field within a flat (non-nested) schema. The index
+     * is adjusted to account for the row key field being excluded from the projected row.
+     */
+    private static QualifierConfig resolveTopLevelQualifierField(
+            DataType physicalSchema, String rowKeyField, String qualifierFieldName) {
+        int adjustedIdx = 0;
+        for (Field field : DataType.getFields(physicalSchema)) {
+            if (field.getName().equals(rowKeyField)) {
+                continue;
+            }
+            if (field.getName().equals(qualifierFieldName)) {
+                return new QualifierConfig(adjustedIdx, field.getDataType().getLogicalType());
+            }
+            adjustedIdx++;
+        }
+        throw new IllegalArgumentException(
+                String.format("Qualifier field '%s' not found in schema", qualifierFieldName));
+    }
+
+    /** Resolves the index and type of a qualifier field within a column family's sub-schema. */
+    private static QualifierConfig resolveQualifierField(
+            DataType physicalSchema, String family, String qualifierFieldName) {
+        for (Field topField : DataType.getFields(physicalSchema)) {
+            if (topField.getName().equals(family)) {
+                int idx = 0;
+                for (Field subField : DataType.getFields(topField.getDataType())) {
+                    if (subField.getName().equals(qualifierFieldName)) {
+                        return new QualifierConfig(idx, subField.getDataType().getLogicalType());
+                    }
+                    idx++;
+                }
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Qualifier field '%s' not found in column family '%s'",
+                                qualifierFieldName, family));
+            }
+        }
+        throw new IllegalArgumentException(
+                String.format("Column family '%s' not found in schema", family));
     }
 }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
@@ -21,6 +21,7 @@ package com.google.flink.connector.gcp.bigtable.table;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.DataTypes.Field;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.format.EncodingFormat;
@@ -108,28 +109,31 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
                     ErrorMessages.QUALIFIER_FIELD_REQUIRES_NESTED_ROWS);
             Set<String> schemaColumnNames =
                     resolvedSchema.getColumns().stream()
-                            .map(c -> c.getName())
+                            .map(Column::getName)
                             .collect(Collectors.toSet());
             this.rawTableOptions.keySet().stream()
                     .filter(k -> k.endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX))
-                    .forEach(k -> {
-                        String family = BigtableConnectorOptions.getFamilyFromQualifierOptionKey(k);
-                        checkArgument(
-                                schemaColumnNames.contains(family),
-                                String.format(
-                                        "Qualifier-field family '%s' not found in schema", family));
-                    });
+                    .forEach(
+                            k -> {
+                                String family =
+                                        BigtableConnectorOptions.getFamilyFromQualifierOptionKey(k);
+                                checkArgument(
+                                        schemaColumnNames.contains(family),
+                                        String.format(
+                                                "Qualifier-field family '%s' not found in schema",
+                                                family));
+                            });
         }
 
         boolean hasTopLevelQualifierField =
-                connectorOptions
-                        .getOptional(BigtableConnectorOptions.QUALIFIER_FIELD)
-                        .isPresent();
+                connectorOptions.getOptional(BigtableConnectorOptions.QUALIFIER_FIELD).isPresent();
         if (hasTopLevelQualifierField) {
             checkArgument(
                     valueEncodingFormat != null, ErrorMessages.QUALIFIER_FIELD_REQUIRES_FORMAT);
             checkArgument(
-                    connectorOptions.getOptional(BigtableConnectorOptions.COLUMN_FAMILY).isPresent(),
+                    connectorOptions
+                            .getOptional(BigtableConnectorOptions.COLUMN_FAMILY)
+                            .isPresent(),
                     "qualifier-field requires column-family to be set");
             checkArgument(
                     !connectorOptions.get(BigtableConnectorOptions.USE_NESTED_ROWS_MODE),
@@ -137,13 +141,14 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
                             + "Use '<family>.qualifier-field' for nested-rows-mode instead.");
             String qualifierFieldName =
                     connectorOptions.get(BigtableConnectorOptions.QUALIFIER_FIELD);
-            boolean fieldExists =
+            Set<String> schemaColumnNames =
                     resolvedSchema.getColumns().stream()
-                            .anyMatch(col -> col.getName().equals(qualifierFieldName));
+                            .map(Column::getName)
+                            .collect(Collectors.toSet());
+            boolean fieldExists = schemaColumnNames.contains(qualifierFieldName);
             checkArgument(
                     fieldExists,
-                    String.format(
-                            "Qualifier field '%s' not found in schema", qualifierFieldName));
+                    String.format("Qualifier field '%s' not found in schema", qualifierFieldName));
             checkArgument(
                     !qualifierFieldName.equals(rowKeyField),
                     "qualifier-field cannot be the same as the primary key field");
@@ -228,8 +233,7 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
                                 .orElse(null);
                 QualifierConfig qualifierConfig =
                         qualifierFieldName != null
-                                ? resolveTopLevelQualifierField(
-                                        physicalSchema, qualifierFieldName)
+                                ? resolveTopLevelQualifierField(physicalSchema, qualifierFieldName)
                                 : null;
                 serializer =
                         FormatAwareRowMutationSerializer.forFlatMode(
@@ -340,8 +344,7 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
         for (Map.Entry<String, String> entry : rawOptions.entrySet()) {
             if (entry.getKey().endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX)) {
                 String family =
-                        BigtableConnectorOptions.getFamilyFromQualifierOptionKey(
-                                entry.getKey());
+                        BigtableConnectorOptions.getFamilyFromQualifierOptionKey(entry.getKey());
                 String qualifierFieldName = entry.getValue();
                 configs.put(
                         family, resolveQualifierField(physicalSchema, family, qualifierFieldName));

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/BigtableDynamicTableSink.java
@@ -99,10 +99,7 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
 
         boolean hasPrefixedQualifierFields =
                 this.rawTableOptions.keySet().stream()
-                        .anyMatch(
-                                k ->
-                                        k.endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX)
-                                                && !k.equals(BigtableConnectorOptions.QUALIFIER_FIELD.key()));
+                        .anyMatch(k -> k.endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX));
         if (hasPrefixedQualifierFields) {
             checkArgument(
                     valueEncodingFormat != null, ErrorMessages.QUALIFIER_FIELD_REQUIRES_FORMAT);
@@ -114,8 +111,7 @@ public class BigtableDynamicTableSink implements DynamicTableSink {
                             .map(c -> c.getName())
                             .collect(Collectors.toSet());
             this.rawTableOptions.keySet().stream()
-                    .filter(k -> k.endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX)
-                            && !k.equals(BigtableConnectorOptions.QUALIFIER_FIELD.key()))
+                    .filter(k -> k.endsWith(BigtableConnectorOptions.QUALIFIER_FIELD_SUFFIX))
                     .forEach(k -> {
                         String family = BigtableConnectorOptions.getFamilyFromQualifierOptionKey(k);
                         checkArgument(

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/config/BigtableConnectorOptions.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/config/BigtableConnectorOptions.java
@@ -127,4 +127,12 @@ public class BigtableConnectorOptions {
                                     + "Requires 'value.format' to be set.");
 
     public static final String QUALIFIER_FIELD_SUFFIX = ".qualifier-field";
+
+    /**
+     * Extracts the column family name from a dynamic qualifier-field option key. For example,
+     * {@code "product.qualifier-field"} returns {@code "product"}.
+     */
+    public static String getFamilyFromQualifierOptionKey(String key) {
+        return key.substring(0, key.length() - QUALIFIER_FIELD_SUFFIX.length());
+    }
 }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/config/BigtableConnectorOptions.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/table/config/BigtableConnectorOptions.java
@@ -20,6 +20,7 @@ package com.google.flink.connector.gcp.bigtable.table.config;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.table.factories.FactoryUtil;
 
 /**
  * Configurations for a Bigtable Table API Write. Needs to be public so that the {@link
@@ -107,4 +108,23 @@ public class BigtableConnectorOptions {
                                     + "'upsert' (INSERT, UPDATE_AFTER, DELETE), "
                                     + "'all' (INSERT, UPDATE_BEFORE, UPDATE_AFTER, DELETE). "
                                     + "Modes other than 'insert-only' require a PRIMARY KEY.");
+
+    public static final ConfigOption<String> VALUE_FORMAT =
+            ConfigOptions.key("value" + FactoryUtil.FORMAT_SUFFIX)
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The format for encoding cell values. "
+                                    + "When set, discovers a SerializationFormatFactory via SPI.");
+
+    public static final ConfigOption<String> QUALIFIER_FIELD =
+            ConfigOptions.key("qualifier-field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Field name to use as the Bigtable column qualifier. "
+                                    + "Works with 'column-family' mode (flat schema). "
+                                    + "Requires 'value.format' to be set.");
+
+    public static final String QUALIFIER_FIELD_SUFFIX = ".qualifier-field";
 }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
@@ -45,4 +45,8 @@ public class ErrorMessages {
     public static final String MULTIPLE_PRIMARY_KEYS_TEMPLATE =
             "There must be exactly one primary key, found %d.";
     public static final String ROW_KEY_NULLABLE = "Row key column must not be nullable";
+    public static final String QUALIFIER_FIELD_REQUIRES_FORMAT =
+            "qualifier-field options require value.format to be set";
+    public static final String QUALIFIER_FIELD_REQUIRES_NESTED_ROWS =
+            "qualifier-field options require use-nested-rows-mode=true";
 }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/main/java/com/google/flink/connector/gcp/bigtable/utils/ErrorMessages.java
@@ -46,7 +46,7 @@ public class ErrorMessages {
             "There must be exactly one primary key, found %d.";
     public static final String ROW_KEY_NULLABLE = "Row key column must not be nullable";
     public static final String QUALIFIER_FIELD_REQUIRES_FORMAT =
-            "qualifier-field options require value.format to be set";
+            "The 'qualifier-field' options require 'value.format' to be set";
     public static final String QUALIFIER_FIELD_REQUIRES_NESTED_ROWS =
-            "qualifier-field options require use-nested-rows-mode=true";
+            "The 'qualifier-field' options require 'use-nested-rows-mode' to be true";
 }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializerTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializerTest.java
@@ -1,0 +1,974 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.flink.connector.gcp.bigtable.serializers;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.types.RowKind;
+
+import com.google.bigtable.v2.Mutation;
+import com.google.bigtable.v2.Mutation.SetCell;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.protobuf.ByteString;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link FormatAwareRowMutationSerializer}. */
+public class FormatAwareRowMutationSerializerTest {
+
+    private static final long TIMESTAMP = 1704067200000L;
+
+    private SinkWriter.Context createContext() {
+        return new SinkWriter.Context() {
+            @Override
+            public long currentWatermark() {
+                return 0;
+            }
+
+            @Override
+            public Long timestamp() {
+                return TIMESTAMP;
+            }
+        };
+    }
+
+    @Test
+    public void testSerializeWithoutQualifierField() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf1",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("shop_id", DataTypes.BIGINT()),
+                                        DataTypes.FIELD("title", DataTypes.STRING()))));
+
+        byte[] expectedBytes = "serialized-cf1".getBytes();
+        SerializationSchema<RowData> mockSerializer = rowData -> expectedBytes;
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("cf1", mockSerializer);
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, Collections.emptyMap(), false);
+
+        GenericRowData cf1Row = new GenericRowData(2);
+        cf1Row.setField(0, 42L);
+        cf1Row.setField(1, StringData.fromString("T-Shirt"));
+
+        GenericRowData record = new GenericRowData(2);
+        record.setField(0, StringData.fromString("row1"));
+        record.setField(1, cf1Row);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        assertEquals(1, entry.toProto().getMutationsCount());
+        SetCell cell = entry.toProto().getMutations(0).getSetCell();
+        assertEquals("cf1", cell.getFamilyName());
+        assertEquals(ByteString.copyFromUtf8("payload"), cell.getColumnQualifier());
+        assertEquals(ByteString.copyFrom(expectedBytes), cell.getValue());
+    }
+
+    @Test
+    public void testSerializeWithQualifierField() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "publications",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("id", DataTypes.BIGINT()),
+                                        DataTypes.FIELD("channel", DataTypes.STRING()))));
+
+        byte[] expectedBytes = "serialized-pub".getBytes();
+        SerializationSchema<RowData> mockSerializer = rowData -> expectedBytes;
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("publications", mockSerializer);
+
+        Map<String, QualifierConfig> qualifierConfigs = new HashMap<>();
+        qualifierConfigs.put("publications", new QualifierConfig(0, new BigIntType()));
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, qualifierConfigs, false);
+
+        GenericRowData pubRow = new GenericRowData(2);
+        pubRow.setField(0, 5001L);
+        pubRow.setField(1, StringData.fromString("online_store"));
+
+        GenericRowData record = new GenericRowData(2);
+        record.setField(0, StringData.fromString("row1"));
+        record.setField(1, pubRow);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        assertEquals(1, entry.toProto().getMutationsCount());
+        SetCell cell = entry.toProto().getMutations(0).getSetCell();
+        assertEquals("publications", cell.getFamilyName());
+        assertEquals(ByteString.copyFromUtf8("5001"), cell.getColumnQualifier());
+        assertEquals(ByteString.copyFrom(expectedBytes), cell.getValue());
+    }
+
+    @Test
+    public void testSerializeSkipsNullFamilies() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf1", DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.STRING()))),
+                        DataTypes.FIELD(
+                                "cf2", DataTypes.ROW(DataTypes.FIELD("f2", DataTypes.STRING()))));
+
+        byte[] bytes1 = "cf1-bytes".getBytes();
+        byte[] bytes2 = "cf2-bytes".getBytes();
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("cf1", rowData -> bytes1);
+        familySerializers.put("cf2", rowData -> bytes2);
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, Collections.emptyMap(), false);
+
+        GenericRowData cf1Row = new GenericRowData(1);
+        cf1Row.setField(0, StringData.fromString("value1"));
+
+        GenericRowData record = new GenericRowData(3);
+        record.setField(0, StringData.fromString("row1"));
+        record.setField(1, cf1Row);
+        record.setField(2, null);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        assertEquals(1, entry.toProto().getMutationsCount());
+        assertEquals("cf1", entry.toProto().getMutations(0).getSetCell().getFamilyName());
+    }
+
+    @Test
+    public void testSerializeMultipleFamiliesMixed() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "product",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("shop_id", DataTypes.BIGINT()),
+                                        DataTypes.FIELD("title", DataTypes.STRING()))),
+                        DataTypes.FIELD(
+                                "publications",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("id", DataTypes.BIGINT()),
+                                        DataTypes.FIELD("channel", DataTypes.STRING()))));
+
+        byte[] productBytes = "product-bytes".getBytes();
+        byte[] pubBytes = "pub-bytes".getBytes();
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("product", rowData -> productBytes);
+        familySerializers.put("publications", rowData -> pubBytes);
+
+        Map<String, QualifierConfig> qualifierConfigs = new HashMap<>();
+        qualifierConfigs.put("publications", new QualifierConfig(0, new BigIntType()));
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, qualifierConfigs, false);
+
+        GenericRowData productRow = new GenericRowData(2);
+        productRow.setField(0, 7L);
+        productRow.setField(1, StringData.fromString("T-Shirt"));
+
+        GenericRowData pubRow = new GenericRowData(2);
+        pubRow.setField(0, 5001L);
+        pubRow.setField(1, StringData.fromString("online_store"));
+
+        GenericRowData record = new GenericRowData(3);
+        record.setField(0, StringData.fromString("1001"));
+        record.setField(1, productRow);
+        record.setField(2, pubRow);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        assertEquals(2, entry.toProto().getMutationsCount());
+
+        SetCell productCell = entry.toProto().getMutations(0).getSetCell();
+        assertEquals("product", productCell.getFamilyName());
+        assertEquals(ByteString.copyFromUtf8("payload"), productCell.getColumnQualifier());
+        assertEquals(ByteString.copyFrom(productBytes), productCell.getValue());
+
+        SetCell pubCell = entry.toProto().getMutations(1).getSetCell();
+        assertEquals("publications", pubCell.getFamilyName());
+        assertEquals(ByteString.copyFromUtf8("5001"), pubCell.getColumnQualifier());
+        assertEquals(ByteString.copyFrom(pubBytes), pubCell.getValue());
+    }
+
+    @Test
+    public void testSerializeFlatModeWithFormat() {
+        // Schema: rowKey STRING, shop_id BIGINT, title STRING
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD("shop_id", DataTypes.BIGINT()),
+                        DataTypes.FIELD("title", DataTypes.STRING()));
+
+        byte[] expectedBytes = "flat-bytes".getBytes();
+        // This mock serializer receives a projected RowData (without rowKey)
+        SerializationSchema<RowData> mockSerializer = rowData -> expectedBytes;
+
+        FormatAwareRowMutationSerializer serializer =
+                FormatAwareRowMutationSerializer.forFlatMode(
+                        schema, "rowKey", "product", mockSerializer, false, null);
+
+        GenericRowData record = new GenericRowData(3);
+        record.setField(0, StringData.fromString("row1"));
+        record.setField(1, 42L);
+        record.setField(2, StringData.fromString("T-Shirt"));
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        assertEquals(1, entry.toProto().getMutationsCount());
+        SetCell cell = entry.toProto().getMutations(0).getSetCell();
+        assertEquals("product", cell.getFamilyName());
+        assertEquals(ByteString.copyFromUtf8("payload"), cell.getColumnQualifier());
+        assertEquals(ByteString.copyFrom(expectedBytes), cell.getValue());
+    }
+
+    @Test
+    public void testSerializeFlatModeWithRowKeyNotAtIndexZero() {
+        // Row key is the last field, not the first
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("shop_id", DataTypes.BIGINT()),
+                        DataTypes.FIELD("title", DataTypes.STRING()),
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()));
+
+        byte[] expectedBytes = "projected-bytes".getBytes();
+        SerializationSchema<RowData> mockSerializer = rowData -> expectedBytes;
+
+        FormatAwareRowMutationSerializer serializer =
+                FormatAwareRowMutationSerializer.forFlatMode(
+                        schema, "rowKey", "product", mockSerializer, false, null);
+
+        GenericRowData record = new GenericRowData(3);
+        record.setField(0, 42L);
+        record.setField(1, StringData.fromString("T-Shirt"));
+        record.setField(2, StringData.fromString("row1"));
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        assertEquals(1, entry.toProto().getMutationsCount());
+        SetCell cell = entry.toProto().getMutations(0).getSetCell();
+        assertEquals("product", cell.getFamilyName());
+        assertEquals(ByteString.copyFromUtf8("payload"), cell.getColumnQualifier());
+        assertEquals(ByteString.copyFrom(expectedBytes), cell.getValue());
+    }
+
+    @Test
+    public void testSerializeNestedModeWithRowKeyNotAtIndexZero() {
+        // Row key is in the middle of the schema
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD(
+                                "cf1",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("shop_id", DataTypes.BIGINT()),
+                                        DataTypes.FIELD("title", DataTypes.STRING()))),
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf2",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("city", DataTypes.STRING()))));
+
+        byte[] cf1Bytes = "cf1-bytes".getBytes();
+        byte[] cf2Bytes = "cf2-bytes".getBytes();
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("cf1", rowData -> cf1Bytes);
+        familySerializers.put("cf2", rowData -> cf2Bytes);
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, Collections.emptyMap(), false);
+
+        GenericRowData cf1Row = new GenericRowData(2);
+        cf1Row.setField(0, 42L);
+        cf1Row.setField(1, StringData.fromString("T-Shirt"));
+
+        GenericRowData cf2Row = new GenericRowData(1);
+        cf2Row.setField(0, StringData.fromString("NYC"));
+
+        GenericRowData record = new GenericRowData(3);
+        record.setField(0, cf1Row);
+        record.setField(1, StringData.fromString("row1"));
+        record.setField(2, cf2Row);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        assertEquals(2, entry.toProto().getMutationsCount());
+
+        java.util.Set<String> families = new java.util.HashSet<>();
+        for (int i = 0; i < entry.toProto().getMutationsCount(); i++) {
+            families.add(entry.toProto().getMutations(i).getSetCell().getFamilyName());
+        }
+        assertTrue(families.contains("cf1"));
+        assertTrue(families.contains("cf2"));
+    }
+
+    @Test
+    public void testSerializeWithStringQualifierField() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "events",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("event_name", DataTypes.STRING()),
+                                        DataTypes.FIELD("payload", DataTypes.STRING()))));
+
+        byte[] bytes = "event-bytes".getBytes();
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("events", rowData -> bytes);
+
+        Map<String, QualifierConfig> qualifierConfigs = new HashMap<>();
+        qualifierConfigs.put("events", new QualifierConfig(0, DataTypes.STRING().getLogicalType()));
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, qualifierConfigs, false);
+
+        GenericRowData eventRow = new GenericRowData(2);
+        eventRow.setField(0, StringData.fromString("click"));
+        eventRow.setField(1, StringData.fromString("{}"));
+
+        GenericRowData record = new GenericRowData(2);
+        record.setField(0, StringData.fromString("user1"));
+        record.setField(1, eventRow);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        SetCell cell = entry.toProto().getMutations(0).getSetCell();
+        assertEquals("events", cell.getFamilyName());
+        assertEquals(ByteString.copyFromUtf8("click"), cell.getColumnQualifier());
+    }
+
+    @Test
+    public void testUpdateBeforeReturnsNullInUpsertMode() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf1",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("shop_id", DataTypes.BIGINT()),
+                                        DataTypes.FIELD("title", DataTypes.STRING()))));
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("cf1", rowData -> "bytes".getBytes());
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, Collections.emptyMap(), true);
+
+        GenericRowData cf1Row = new GenericRowData(2);
+        cf1Row.setField(0, 42L);
+        cf1Row.setField(1, StringData.fromString("T-Shirt"));
+
+        GenericRowData record = new GenericRowData(2);
+        record.setField(0, StringData.fromString("row1"));
+        record.setField(1, cf1Row);
+        record.setRowKind(RowKind.UPDATE_BEFORE);
+
+        assertNull(serializer.serialize(record, createContext()));
+    }
+
+    @Test
+    public void testInsertStillWorksInUpsertMode() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf1",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("shop_id", DataTypes.BIGINT()),
+                                        DataTypes.FIELD("title", DataTypes.STRING()))));
+
+        byte[] expectedBytes = "serialized".getBytes();
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("cf1", rowData -> expectedBytes);
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, Collections.emptyMap(), true);
+
+        GenericRowData cf1Row = new GenericRowData(2);
+        cf1Row.setField(0, 42L);
+        cf1Row.setField(1, StringData.fromString("T-Shirt"));
+
+        GenericRowData record = new GenericRowData(2);
+        record.setField(0, StringData.fromString("row1"));
+        record.setField(1, cf1Row);
+        record.setRowKind(RowKind.INSERT);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+        assertEquals(1, entry.toProto().getMutationsCount());
+        assertEquals("cf1", entry.toProto().getMutations(0).getSetCell().getFamilyName());
+    }
+
+    @Test
+    public void testDeleteNestedModeWithoutQualifierField() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf1", DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.STRING()))),
+                        DataTypes.FIELD(
+                                "cf2", DataTypes.ROW(DataTypes.FIELD("f2", DataTypes.STRING()))));
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("cf1", rowData -> "bytes".getBytes());
+        familySerializers.put("cf2", rowData -> "bytes".getBytes());
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, Collections.emptyMap(), true);
+
+        GenericRowData record = new GenericRowData(3);
+        record.setField(0, StringData.fromString("row1"));
+        record.setField(1, null);
+        record.setField(2, null);
+        record.setRowKind(RowKind.DELETE);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        // Should produce deleteFamily mutations for cf1 and cf2
+        assertEquals(2, entry.toProto().getMutationsCount());
+
+        // Collect family names from mutations (order may vary due to HashMap)
+        java.util.Set<String> deletedFamilies = new java.util.HashSet<>();
+        for (int i = 0; i < entry.toProto().getMutationsCount(); i++) {
+            assertTrue(entry.toProto().getMutations(i).hasDeleteFromFamily());
+            deletedFamilies.add(
+                    entry.toProto().getMutations(i).getDeleteFromFamily().getFamilyName());
+        }
+        assertTrue(deletedFamilies.contains("cf1"));
+        assertTrue(deletedFamilies.contains("cf2"));
+    }
+
+    @Test
+    public void testDeleteWithQualifierFieldDeletesSpecificCell() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "product",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("shop_id", DataTypes.BIGINT()),
+                                        DataTypes.FIELD("title", DataTypes.STRING()))),
+                        DataTypes.FIELD(
+                                "publications",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("id", DataTypes.BIGINT()),
+                                        DataTypes.FIELD("channel", DataTypes.STRING()))));
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("product", rowData -> "bytes".getBytes());
+        familySerializers.put("publications", rowData -> "bytes".getBytes());
+
+        Map<String, QualifierConfig> qualifierConfigs = new HashMap<>();
+        qualifierConfigs.put("publications", new QualifierConfig(0, new BigIntType()));
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, qualifierConfigs, true);
+
+        // DELETE: product is null, publications has id=5001
+        GenericRowData pubRow = new GenericRowData(2);
+        pubRow.setField(0, 5001L);
+        pubRow.setField(1, StringData.fromString("online_store"));
+
+        GenericRowData record = new GenericRowData(3);
+        record.setField(0, StringData.fromString("1001"));
+        record.setField(1, null);
+        record.setField(2, pubRow);
+        record.setRowKind(RowKind.DELETE);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        // product: deleteFamily (no qualifier config)
+        // publications: deleteCells (has qualifier config, sub-row is non-null)
+        assertEquals(2, entry.toProto().getMutationsCount());
+
+        // Find each mutation by type since HashMap ordering is non-deterministic
+        Mutation productMutation = null;
+        Mutation pubMutation = null;
+        for (int i = 0; i < entry.toProto().getMutationsCount(); i++) {
+            Mutation m = entry.toProto().getMutations(i);
+            if (m.hasDeleteFromFamily()) {
+                productMutation = m;
+            } else if (m.hasDeleteFromColumn()) {
+                pubMutation = m;
+            }
+        }
+
+        assertNotNull(productMutation);
+        assertEquals("product", productMutation.getDeleteFromFamily().getFamilyName());
+
+        assertNotNull(pubMutation);
+        assertEquals("publications", pubMutation.getDeleteFromColumn().getFamilyName());
+        assertEquals(
+                ByteString.copyFromUtf8("5001"),
+                pubMutation.getDeleteFromColumn().getColumnQualifier());
+    }
+
+    @Test
+    public void testDeleteFlatMode() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD("shop_id", DataTypes.BIGINT()),
+                        DataTypes.FIELD("title", DataTypes.STRING()));
+
+        FormatAwareRowMutationSerializer serializer =
+                FormatAwareRowMutationSerializer.forFlatMode(
+                        schema, "rowKey", "product", rowData -> "bytes".getBytes(), true, null);
+
+        GenericRowData record = new GenericRowData(3);
+        record.setField(0, StringData.fromString("row1"));
+        record.setField(1, 42L);
+        record.setField(2, StringData.fromString("T-Shirt"));
+        record.setRowKind(RowKind.DELETE);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        assertEquals(1, entry.toProto().getMutationsCount());
+        assertTrue(entry.toProto().getMutations(0).hasDeleteFromFamily());
+        assertEquals(
+                "product", entry.toProto().getMutations(0).getDeleteFromFamily().getFamilyName());
+    }
+
+    @Test
+    public void testNonUpsertModeIgnoresRowKind() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf1", DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.STRING()))));
+
+        byte[] expectedBytes = "bytes".getBytes();
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("cf1", rowData -> expectedBytes);
+
+        // upsertMode = false
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, Collections.emptyMap(), false);
+
+        GenericRowData cf1Row = new GenericRowData(1);
+        cf1Row.setField(0, StringData.fromString("value"));
+
+        GenericRowData record = new GenericRowData(2);
+        record.setField(0, StringData.fromString("row1"));
+        record.setField(1, cf1Row);
+        record.setRowKind(RowKind.DELETE); // should be ignored in non-upsert mode
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        // Should produce a normal setCell, not a delete
+        assertNotNull(entry);
+        assertEquals(1, entry.toProto().getMutationsCount());
+        assertTrue(entry.toProto().getMutations(0).hasSetCell());
+    }
+
+    @Test
+    public void testSerializeFlatModeWithQualifierField() {
+        // Schema: rowKey STRING, product_id STRING, name STRING, price BIGINT
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD("product_id", DataTypes.STRING()),
+                        DataTypes.FIELD("name", DataTypes.STRING()),
+                        DataTypes.FIELD("price", DataTypes.BIGINT()));
+
+        byte[] expectedBytes = "flat-qualifier-bytes".getBytes();
+        SerializationSchema<RowData> mockSerializer = rowData -> expectedBytes;
+
+        // product_id is at adjusted index 0 (after row key exclusion)
+        QualifierConfig qualifierConfig =
+                new QualifierConfig(0, DataTypes.STRING().getLogicalType());
+
+        FormatAwareRowMutationSerializer serializer =
+                FormatAwareRowMutationSerializer.forFlatMode(
+                        schema, "rowKey", "products", mockSerializer, false,
+                        qualifierConfig);
+
+        GenericRowData record = new GenericRowData(4);
+        record.setField(0, StringData.fromString("shop1"));
+        record.setField(1, StringData.fromString("prod-42"));
+        record.setField(2, StringData.fromString("T-Shirt"));
+        record.setField(3, 2999L);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        assertEquals(1, entry.toProto().getMutationsCount());
+        SetCell cell = entry.toProto().getMutations(0).getSetCell();
+        assertEquals("products", cell.getFamilyName());
+        assertEquals(ByteString.copyFromUtf8("prod-42"), cell.getColumnQualifier());
+        assertEquals(ByteString.copyFrom(expectedBytes), cell.getValue());
+    }
+
+    @Test
+    public void testDeleteFlatModeWithQualifierField() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD("product_id", DataTypes.STRING()),
+                        DataTypes.FIELD("name", DataTypes.STRING()),
+                        DataTypes.FIELD("price", DataTypes.BIGINT()));
+
+        QualifierConfig qualifierConfig =
+                new QualifierConfig(0, DataTypes.STRING().getLogicalType());
+
+        FormatAwareRowMutationSerializer serializer =
+                FormatAwareRowMutationSerializer.forFlatMode(
+                        schema, "rowKey", "products",
+                        rowData -> "bytes".getBytes(), true, qualifierConfig);
+
+        GenericRowData record = new GenericRowData(4);
+        record.setField(0, StringData.fromString("shop1"));
+        record.setField(1, StringData.fromString("prod-42"));
+        record.setField(2, StringData.fromString("T-Shirt"));
+        record.setField(3, 2999L);
+        record.setRowKind(RowKind.DELETE);
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        assertEquals(1, entry.toProto().getMutationsCount());
+        assertTrue(entry.toProto().getMutations(0).hasDeleteFromColumn());
+        assertEquals(
+                "products",
+                entry.toProto().getMutations(0).getDeleteFromColumn().getFamilyName());
+        assertEquals(
+                ByteString.copyFromUtf8("prod-42"),
+                entry.toProto().getMutations(0).getDeleteFromColumn().getColumnQualifier());
+    }
+
+    @Test
+    public void testSerializeFlatModeWithIntegerQualifierField() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD("product_id", DataTypes.BIGINT()),
+                        DataTypes.FIELD("name", DataTypes.STRING()));
+
+        byte[] expectedBytes = "int-qualifier-bytes".getBytes();
+        SerializationSchema<RowData> mockSerializer = rowData -> expectedBytes;
+
+        QualifierConfig qualifierConfig =
+                new QualifierConfig(0, new BigIntType());
+
+        FormatAwareRowMutationSerializer serializer =
+                FormatAwareRowMutationSerializer.forFlatMode(
+                        schema, "rowKey", "products", mockSerializer, false,
+                        qualifierConfig);
+
+        GenericRowData record = new GenericRowData(3);
+        record.setField(0, StringData.fromString("shop1"));
+        record.setField(1, 42L);
+        record.setField(2, StringData.fromString("T-Shirt"));
+
+        RowMutationEntry entry = serializer.serialize(record, createContext());
+
+        assertEquals(1, entry.toProto().getMutationsCount());
+        SetCell cell = entry.toProto().getMutations(0).getSetCell();
+        assertEquals("products", cell.getFamilyName());
+        assertEquals(ByteString.copyFromUtf8("42"), cell.getColumnQualifier());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullQualifierFieldThrowsInNestedMode() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "events",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("event_name", DataTypes.STRING()),
+                                        DataTypes.FIELD("payload", DataTypes.STRING()))));
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("events", rowData -> "bytes".getBytes());
+
+        Map<String, QualifierConfig> qualifierConfigs = new HashMap<>();
+        qualifierConfigs.put("events", new QualifierConfig(0, DataTypes.STRING().getLogicalType()));
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, qualifierConfigs, false);
+
+        GenericRowData eventRow = new GenericRowData(2);
+        eventRow.setField(0, null); // null qualifier field
+        eventRow.setField(1, StringData.fromString("{}"));
+
+        GenericRowData record = new GenericRowData(2);
+        record.setField(0, StringData.fromString("user1"));
+        record.setField(1, eventRow);
+
+        serializer.serialize(record, createContext());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullQualifierFieldThrowsInFlatMode() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD("product_id", DataTypes.STRING()),
+                        DataTypes.FIELD("name", DataTypes.STRING()));
+
+        QualifierConfig qualifierConfig =
+                new QualifierConfig(0, DataTypes.STRING().getLogicalType());
+
+        FormatAwareRowMutationSerializer serializer =
+                FormatAwareRowMutationSerializer.forFlatMode(
+                        schema, "rowKey", "products",
+                        rowData -> "bytes".getBytes(), false, qualifierConfig);
+
+        GenericRowData record = new GenericRowData(3);
+        record.setField(0, StringData.fromString("shop1"));
+        record.setField(1, null); // null qualifier field
+        record.setField(2, StringData.fromString("T-Shirt"));
+
+        serializer.serialize(record, createContext());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRowKeyFieldThrowsInFlatMode() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD("name", DataTypes.STRING()));
+
+        FormatAwareRowMutationSerializer.forFlatMode(
+                schema, "nonExistentKey", "product",
+                rowData -> "bytes".getBytes(), false, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRowKeyFieldThrowsInNestedMode() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf1", DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.STRING()))));
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("cf1", rowData -> "bytes".getBytes());
+
+        new FormatAwareRowMutationSerializer(
+                schema, "nonExistentKey", familySerializers, Collections.emptyMap(), false);
+    }
+
+    // --- Flat mode constructor null checks ---
+
+    @Test(expected = NullPointerException.class)
+    public void testFlatModeNullSchemaThrows() {
+        FormatAwareRowMutationSerializer.forFlatMode(
+                null, "rowKey", "cf1", rowData -> "bytes".getBytes(), false, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testFlatModeNullRowKeyFieldThrows() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD("name", DataTypes.STRING()));
+
+        FormatAwareRowMutationSerializer.forFlatMode(
+                schema, null, "cf1", rowData -> "bytes".getBytes(), false, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testFlatModeNullColumnFamilyThrows() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD("name", DataTypes.STRING()));
+
+        FormatAwareRowMutationSerializer.forFlatMode(
+                schema, "rowKey", null, rowData -> "bytes".getBytes(), false, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testFlatModeNullSerializerThrows() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD("name", DataTypes.STRING()));
+
+        FormatAwareRowMutationSerializer.forFlatMode(
+                schema, "rowKey", "cf1", null, false, null);
+    }
+
+    // --- Nested mode constructor null checks ---
+
+    @Test(expected = NullPointerException.class)
+    public void testNestedModeNullSchemaThrows() {
+        new FormatAwareRowMutationSerializer(
+                null, "rowKey", new HashMap<>(), Collections.emptyMap(), false);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNestedModeNullRowKeyFieldThrows() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf1", DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.STRING()))));
+
+        new FormatAwareRowMutationSerializer(
+                schema, null, new HashMap<>(), Collections.emptyMap(), false);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNestedModeNullFamilySerializersThrows() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf1", DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.STRING()))));
+
+        new FormatAwareRowMutationSerializer(
+                schema, "rowKey", null, Collections.emptyMap(), false);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNestedModeNullQualifierConfigsThrows() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf1", DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.STRING()))));
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("cf1", rowData -> "bytes".getBytes());
+
+        new FormatAwareRowMutationSerializer(
+                schema, "rowKey", familySerializers, null, false);
+    }
+
+    @Test
+    public void testOpenDelegatesToFlatSerializer() throws Exception {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD("name", DataTypes.STRING()));
+
+        AtomicBoolean opened = new AtomicBoolean(false);
+        SerializationSchema<RowData> trackingSerializer =
+                new SerializationSchema<RowData>() {
+                    @Override
+                    public void open(InitializationContext context) {
+                        opened.set(true);
+                    }
+
+                    @Override
+                    public byte[] serialize(RowData element) {
+                        return new byte[0];
+                    }
+                };
+
+        FormatAwareRowMutationSerializer serializer =
+                FormatAwareRowMutationSerializer.forFlatMode(
+                        schema, "rowKey", "cf1", trackingSerializer, false, null);
+
+        serializer.open(null);
+
+        assertTrue("open() should delegate to flat serializer", opened.get());
+    }
+
+    @Test
+    public void testOpenDelegatesToAllFamilySerializers() throws Exception {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "cf1", DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.STRING()))),
+                        DataTypes.FIELD(
+                                "cf2", DataTypes.ROW(DataTypes.FIELD("f2", DataTypes.STRING()))));
+
+        AtomicBoolean cf1Opened = new AtomicBoolean(false);
+        AtomicBoolean cf2Opened = new AtomicBoolean(false);
+
+        SerializationSchema<RowData> cf1Serializer =
+                new SerializationSchema<RowData>() {
+                    @Override
+                    public void open(InitializationContext context) {
+                        cf1Opened.set(true);
+                    }
+
+                    @Override
+                    public byte[] serialize(RowData element) {
+                        return new byte[0];
+                    }
+                };
+
+        SerializationSchema<RowData> cf2Serializer =
+                new SerializationSchema<RowData>() {
+                    @Override
+                    public void open(InitializationContext context) {
+                        cf2Opened.set(true);
+                    }
+
+                    @Override
+                    public byte[] serialize(RowData element) {
+                        return new byte[0];
+                    }
+                };
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("cf1", cf1Serializer);
+        familySerializers.put("cf2", cf2Serializer);
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, Collections.emptyMap(), false);
+
+        serializer.open(null);
+
+        assertTrue("open() should delegate to cf1 serializer", cf1Opened.get());
+        assertTrue("open() should delegate to cf2 serializer", cf2Opened.get());
+    }
+}

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializerTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializerTest.java
@@ -554,6 +554,35 @@ public class FormatAwareRowMutationSerializerTest {
                 pubMutation.getDeleteFromColumn().getColumnQualifier());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteNestedModeNullSubRowWithQualifierFieldThrows() {
+        DataType schema =
+                DataTypes.ROW(
+                        DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
+                        DataTypes.FIELD(
+                                "product",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("id", DataTypes.BIGINT()),
+                                        DataTypes.FIELD("title", DataTypes.STRING()))));
+
+        Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
+        familySerializers.put("product", rowData -> "bytes".getBytes());
+
+        Map<String, QualifierConfig> qualifierConfigs = new HashMap<>();
+        qualifierConfigs.put("product", new QualifierConfig(0, new BigIntType()));
+
+        FormatAwareRowMutationSerializer serializer =
+                new FormatAwareRowMutationSerializer(
+                        schema, "rowKey", familySerializers, qualifierConfigs, true);
+
+        GenericRowData record = new GenericRowData(2);
+        record.setField(0, StringData.fromString("row1"));
+        record.setField(1, null); // null sub-row with qualifier-field configured
+        record.setRowKind(RowKind.DELETE);
+
+        serializer.serialize(record, createContext());
+    }
+
     @Test
     public void testDeleteFlatMode() {
         DataType schema =

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializerTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializerTest.java
@@ -245,7 +245,6 @@ public class FormatAwareRowMutationSerializerTest {
                         DataTypes.FIELD("title", DataTypes.STRING()));
 
         byte[] expectedBytes = "flat-bytes".getBytes();
-        // This mock serializer receives a projected RowData (without rowKey)
         SerializationSchema<RowData> mockSerializer = rowData -> expectedBytes;
 
         FormatAwareRowMutationSerializer serializer =
@@ -275,7 +274,7 @@ public class FormatAwareRowMutationSerializerTest {
                         DataTypes.FIELD("title", DataTypes.STRING()),
                         DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()));
 
-        byte[] expectedBytes = "projected-bytes".getBytes();
+        byte[] expectedBytes = "flat-bytes".getBytes();
         SerializationSchema<RowData> mockSerializer = rowData -> expectedBytes;
 
         FormatAwareRowMutationSerializer serializer =
@@ -655,9 +654,9 @@ public class FormatAwareRowMutationSerializerTest {
         byte[] expectedBytes = "flat-qualifier-bytes".getBytes();
         SerializationSchema<RowData> mockSerializer = rowData -> expectedBytes;
 
-        // product_id is at adjusted index 0 (after row key exclusion)
+        // product_id is at index 1 in the full schema (rowKey is at 0)
         QualifierConfig qualifierConfig =
-                new QualifierConfig(0, DataTypes.STRING().getLogicalType());
+                new QualifierConfig(1, DataTypes.STRING().getLogicalType());
 
         FormatAwareRowMutationSerializer serializer =
                 FormatAwareRowMutationSerializer.forFlatMode(
@@ -688,8 +687,9 @@ public class FormatAwareRowMutationSerializerTest {
                         DataTypes.FIELD("name", DataTypes.STRING()),
                         DataTypes.FIELD("price", DataTypes.BIGINT()));
 
+        // product_id is at index 1 in the full schema (rowKey is at 0)
         QualifierConfig qualifierConfig =
-                new QualifierConfig(0, DataTypes.STRING().getLogicalType());
+                new QualifierConfig(1, DataTypes.STRING().getLogicalType());
 
         FormatAwareRowMutationSerializer serializer =
                 FormatAwareRowMutationSerializer.forFlatMode(
@@ -726,8 +726,9 @@ public class FormatAwareRowMutationSerializerTest {
         byte[] expectedBytes = "int-qualifier-bytes".getBytes();
         SerializationSchema<RowData> mockSerializer = rowData -> expectedBytes;
 
+        // product_id is at index 1 in the full schema (rowKey is at 0)
         QualifierConfig qualifierConfig =
-                new QualifierConfig(0, new BigIntType());
+                new QualifierConfig(1, new BigIntType());
 
         FormatAwareRowMutationSerializer serializer =
                 FormatAwareRowMutationSerializer.forFlatMode(
@@ -787,8 +788,9 @@ public class FormatAwareRowMutationSerializerTest {
                         DataTypes.FIELD("product_id", DataTypes.STRING()),
                         DataTypes.FIELD("name", DataTypes.STRING()));
 
+        // product_id is at index 1 in the full schema (rowKey is at 0)
         QualifierConfig qualifierConfig =
-                new QualifierConfig(0, DataTypes.STRING().getLogicalType());
+                new QualifierConfig(1, DataTypes.STRING().getLogicalType());
 
         FormatAwareRowMutationSerializer serializer =
                 FormatAwareRowMutationSerializer.forFlatMode(

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializerTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/FormatAwareRowMutationSerializerTest.java
@@ -307,9 +307,7 @@ public class FormatAwareRowMutationSerializerTest {
                                         DataTypes.FIELD("title", DataTypes.STRING()))),
                         DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
                         DataTypes.FIELD(
-                                "cf2",
-                                DataTypes.ROW(
-                                        DataTypes.FIELD("city", DataTypes.STRING()))));
+                                "cf2", DataTypes.ROW(DataTypes.FIELD("city", DataTypes.STRING()))));
 
         byte[] cf1Bytes = "cf1-bytes".getBytes();
         byte[] cf2Bytes = "cf2-bytes".getBytes();
@@ -660,8 +658,7 @@ public class FormatAwareRowMutationSerializerTest {
 
         FormatAwareRowMutationSerializer serializer =
                 FormatAwareRowMutationSerializer.forFlatMode(
-                        schema, "rowKey", "products", mockSerializer, false,
-                        qualifierConfig);
+                        schema, "rowKey", "products", mockSerializer, false, qualifierConfig);
 
         GenericRowData record = new GenericRowData(4);
         record.setField(0, StringData.fromString("shop1"));
@@ -693,8 +690,12 @@ public class FormatAwareRowMutationSerializerTest {
 
         FormatAwareRowMutationSerializer serializer =
                 FormatAwareRowMutationSerializer.forFlatMode(
-                        schema, "rowKey", "products",
-                        rowData -> "bytes".getBytes(), true, qualifierConfig);
+                        schema,
+                        "rowKey",
+                        "products",
+                        rowData -> "bytes".getBytes(),
+                        true,
+                        qualifierConfig);
 
         GenericRowData record = new GenericRowData(4);
         record.setField(0, StringData.fromString("shop1"));
@@ -708,8 +709,7 @@ public class FormatAwareRowMutationSerializerTest {
         assertEquals(1, entry.toProto().getMutationsCount());
         assertTrue(entry.toProto().getMutations(0).hasDeleteFromColumn());
         assertEquals(
-                "products",
-                entry.toProto().getMutations(0).getDeleteFromColumn().getFamilyName());
+                "products", entry.toProto().getMutations(0).getDeleteFromColumn().getFamilyName());
         assertEquals(
                 ByteString.copyFromUtf8("prod-42"),
                 entry.toProto().getMutations(0).getDeleteFromColumn().getColumnQualifier());
@@ -727,13 +727,11 @@ public class FormatAwareRowMutationSerializerTest {
         SerializationSchema<RowData> mockSerializer = rowData -> expectedBytes;
 
         // product_id is at index 1 in the full schema (rowKey is at 0)
-        QualifierConfig qualifierConfig =
-                new QualifierConfig(1, new BigIntType());
+        QualifierConfig qualifierConfig = new QualifierConfig(1, new BigIntType());
 
         FormatAwareRowMutationSerializer serializer =
                 FormatAwareRowMutationSerializer.forFlatMode(
-                        schema, "rowKey", "products", mockSerializer, false,
-                        qualifierConfig);
+                        schema, "rowKey", "products", mockSerializer, false, qualifierConfig);
 
         GenericRowData record = new GenericRowData(3);
         record.setField(0, StringData.fromString("shop1"));
@@ -794,8 +792,12 @@ public class FormatAwareRowMutationSerializerTest {
 
         FormatAwareRowMutationSerializer serializer =
                 FormatAwareRowMutationSerializer.forFlatMode(
-                        schema, "rowKey", "products",
-                        rowData -> "bytes".getBytes(), false, qualifierConfig);
+                        schema,
+                        "rowKey",
+                        "products",
+                        rowData -> "bytes".getBytes(),
+                        false,
+                        qualifierConfig);
 
         GenericRowData record = new GenericRowData(3);
         record.setField(0, StringData.fromString("shop1"));
@@ -813,8 +815,7 @@ public class FormatAwareRowMutationSerializerTest {
                         DataTypes.FIELD("name", DataTypes.STRING()));
 
         FormatAwareRowMutationSerializer.forFlatMode(
-                schema, "nonExistentKey", "product",
-                rowData -> "bytes".getBytes(), false, null);
+                schema, "nonExistentKey", "product", rowData -> "bytes".getBytes(), false, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -869,8 +870,7 @@ public class FormatAwareRowMutationSerializerTest {
                         DataTypes.FIELD("rowKey", DataTypes.STRING().notNull()),
                         DataTypes.FIELD("name", DataTypes.STRING()));
 
-        FormatAwareRowMutationSerializer.forFlatMode(
-                schema, "rowKey", "cf1", null, false, null);
+        FormatAwareRowMutationSerializer.forFlatMode(schema, "rowKey", "cf1", null, false, null);
     }
 
     // --- Nested mode constructor null checks ---
@@ -901,8 +901,7 @@ public class FormatAwareRowMutationSerializerTest {
                         DataTypes.FIELD(
                                 "cf1", DataTypes.ROW(DataTypes.FIELD("f1", DataTypes.STRING()))));
 
-        new FormatAwareRowMutationSerializer(
-                schema, "rowKey", null, Collections.emptyMap(), false);
+        new FormatAwareRowMutationSerializer(schema, "rowKey", null, Collections.emptyMap(), false);
     }
 
     @Test(expected = NullPointerException.class)
@@ -916,8 +915,7 @@ public class FormatAwareRowMutationSerializerTest {
         Map<String, SerializationSchema<RowData>> familySerializers = new HashMap<>();
         familySerializers.put("cf1", rowData -> "bytes".getBytes());
 
-        new FormatAwareRowMutationSerializer(
-                schema, "rowKey", familySerializers, null, false);
+        new FormatAwareRowMutationSerializer(schema, "rowKey", familySerializers, null, false);
     }
 
     @Test

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/QualifierConfigTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/serializers/QualifierConfigTest.java
@@ -18,28 +18,32 @@
 
 package com.google.flink.connector.gcp.bigtable.serializers;
 
-import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.VarCharType;
 
-import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import org.junit.Test;
 
-import javax.annotation.Nullable;
+import static org.junit.Assert.assertEquals;
 
-import java.io.Serializable;
+/** Tests for {@link QualifierConfig}. */
+public class QualifierConfigTest {
 
-/**
- * Base serializer class.
- *
- * <p>This class implements the interface to serialize to {@link RowMutationEntry}.
- */
-public interface BaseRowMutationSerializer<T> extends Serializable {
+    @Test
+    public void testQualifierConfigCreation() {
+        LogicalType type = new BigIntType();
+        QualifierConfig config = new QualifierConfig(2, type);
 
-    /**
-     * Initializes the serializer. Called once before the first call to {@link #serialize}. Default
-     * implementation is a no-op for backward compatibility.
-     */
-    default void open(SerializationSchema.InitializationContext context) throws Exception {}
+        assertEquals(2, config.fieldIndex());
+        assertEquals(type, config.fieldType());
+    }
 
-    @Nullable
-    RowMutationEntry serialize(T element, SinkWriter.Context context);
+    @Test
+    public void testQualifierConfigWithStringType() {
+        LogicalType type = new VarCharType();
+        QualifierConfig config = new QualifierConfig(0, type);
+
+        assertEquals(0, config.fieldIndex());
+        assertEquals(type, config.fieldType());
+    }
 }

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/table/BigtableTableTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/table/BigtableTableTest.java
@@ -49,6 +49,7 @@ import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -379,6 +380,119 @@ public class BigtableTableTest {
     }
 
     @Test
+    public void testDynamicTableBigtableSinkWithValueFormat() throws IOException {
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigtableConnectorOptions.USE_NESTED_ROWS_MODE.key(), "true");
+        options.put("value.format", "json");
+
+        ResolvedSchema schema = getResolvedSchema(true);
+
+        BigtableDynamicTableSink sink =
+                (BigtableDynamicTableSink) FactoryMocks.createTableSink(schema, options);
+
+        assertEquals(sink.rowKeyField, TestingUtils.ROW_KEY_FIELD);
+    }
+
+    @Test
+    public void testDynamicTableBigtableSinkWithQualifierField() throws IOException {
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigtableConnectorOptions.USE_NESTED_ROWS_MODE.key(), "true");
+        options.put("value.format", "json");
+        options.put("nested2.qualifier-field", "stringField2");
+
+        ResolvedSchema schema = getResolvedSchema(true);
+
+        BigtableDynamicTableSink sink =
+                (BigtableDynamicTableSink) FactoryMocks.createTableSink(schema, options);
+
+        assertEquals(sink.rowKeyField, TestingUtils.ROW_KEY_FIELD);
+    }
+
+    @Test
+    public void testDynamicTableBigtableSinkFlatModeWithFormat() throws IOException {
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigtableConnectorOptions.COLUMN_FAMILY.key(), TestingUtils.COLUMN_FAMILY);
+        options.put("value.format", "json");
+
+        ResolvedSchema schema = getResolvedSchema(false);
+
+        BigtableDynamicTableSink sink =
+                (BigtableDynamicTableSink) FactoryMocks.createTableSink(schema, options);
+
+        assertNotNull(sink.valueEncodingFormat);
+        assertEquals(sink.rowKeyField, TestingUtils.ROW_KEY_FIELD);
+    }
+
+    @Test
+    public void testPrefixedQualifierFieldWithUnknownFamilyThrows() {
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigtableConnectorOptions.USE_NESTED_ROWS_MODE.key(), "true");
+        options.put("value.format", "json");
+        options.put("nonExistentFamily.qualifier-field", "someField");
+
+        ResolvedSchema schema = getResolvedSchema(true);
+
+        Assertions.assertThatThrownBy(() -> FactoryMocks.createTableSink(schema, options))
+                .hasStackTraceContaining(
+                        "Qualifier-field family 'nonExistentFamily' not found in schema");
+    }
+
+    @Test
+    public void testQualifierFieldRequiresFormat() {
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigtableConnectorOptions.USE_NESTED_ROWS_MODE.key(), "true");
+        options.put("nested1.qualifier-field", "stringField");
+        // No value.format set
+
+        ResolvedSchema schema = getResolvedSchema(true);
+
+        Assertions.assertThatThrownBy(() -> FactoryMocks.createTableSink(schema, options))
+                .hasRootCauseMessage(ErrorMessages.QUALIFIER_FIELD_REQUIRES_FORMAT);
+    }
+
+    @Test
+    public void testQualifierFieldRequiresNestedRowsMode() {
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigtableConnectorOptions.USE_NESTED_ROWS_MODE.key(), "false");
+        options.put("value.format", "json");
+        options.put("nested1.qualifier-field", "stringField");
+
+        ResolvedSchema schema = getResolvedSchema(true);
+
+        Assertions.assertThatThrownBy(() -> FactoryMocks.createTableSink(schema, options))
+                .hasRootCauseMessage(ErrorMessages.QUALIFIER_FIELD_REQUIRES_NESTED_ROWS);
+    }
+
+    @Test
+    public void testLegacyFlatModeStillWorks() {
+        // Exact same setup as testDynamicTableBigtableSink — verify nothing changed
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigtableConnectorOptions.COLUMN_FAMILY.key(), TestingUtils.COLUMN_FAMILY);
+
+        ResolvedSchema schema = getResolvedSchema(false);
+
+        BigtableDynamicTableSink sink =
+                (BigtableDynamicTableSink) FactoryMocks.createTableSink(schema, options);
+
+        assertNull(sink.valueEncodingFormat);
+        assertFalse(sink.connectorOptions.get(BigtableConnectorOptions.USE_NESTED_ROWS_MODE));
+    }
+
+    @Test
+    public void testLegacyNestedModeStillWorks() {
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigtableConnectorOptions.USE_NESTED_ROWS_MODE.key(), "true");
+
+        ResolvedSchema schema = getResolvedSchema(true);
+
+        BigtableDynamicTableSink sink =
+                (BigtableDynamicTableSink) FactoryMocks.createTableSink(schema, options);
+
+        assertNull(sink.valueEncodingFormat);
+        assertTrue(sink.connectorOptions.get(BigtableConnectorOptions.USE_NESTED_ROWS_MODE));
+    }
+
+    @Test
     public void testUpsertModeChangelogMode() throws IOException {
         Map<String, String> options = getRequiredOptions();
         options.put(BigtableConnectorOptions.COLUMN_FAMILY.key(), TestingUtils.COLUMN_FAMILY);
@@ -470,6 +584,19 @@ public class BigtableTableTest {
 
         assertEquals(sink2, sink.copy());
         assertTrue(sink2.equals(sink.copy()));
+    }
+
+    @Test
+    public void testQualifierFieldNotInSchemaThrows() {
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigtableConnectorOptions.COLUMN_FAMILY.key(), TestingUtils.COLUMN_FAMILY);
+        options.put("value.format", "json");
+        options.put(BigtableConnectorOptions.QUALIFIER_FIELD.key(), "nonExistentField");
+
+        ResolvedSchema schema = getResolvedSchema(false);
+
+        Assertions.assertThatThrownBy(() -> FactoryMocks.createTableSink(schema, options))
+                .hasStackTraceContaining("Qualifier field 'nonExistentField' not found in schema");
     }
 
     private static ResolvedSchema getResolvedSchema(Boolean useNestedRowsMode) {

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/table/BigtableTableTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/table/BigtableTableTest.java
@@ -613,6 +613,17 @@ public class BigtableTableTest {
                 .hasStackTraceContaining("Qualifier field 'nonExistentField' not found in schema");
     }
 
+    @Test
+    public void testGetFamilyFromQualifierOptionKey() {
+        assertEquals(
+                "product",
+                BigtableConnectorOptions.getFamilyFromQualifierOptionKey(
+                        "product.qualifier-field"));
+        assertEquals(
+                "cf1",
+                BigtableConnectorOptions.getFamilyFromQualifierOptionKey("cf1.qualifier-field"));
+    }
+
     private static ResolvedSchema getResolvedSchema(Boolean useNestedRowsMode) {
         List<Column> schemaList = useNestedRowsMode ? NESTED_SCHEMA_LIST : SCHEMA_LIST;
 

--- a/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/table/BigtableTableTest.java
+++ b/connectors/bigtable/flink-connector-gcp-bigtable/src/test/java/com/google/flink/connector/gcp/bigtable/table/BigtableTableTest.java
@@ -587,6 +587,20 @@ public class BigtableTableTest {
     }
 
     @Test
+    public void testQualifierFieldCannotBeRowKeyField() {
+        Map<String, String> options = getRequiredOptions();
+        options.put(BigtableConnectorOptions.COLUMN_FAMILY.key(), TestingUtils.COLUMN_FAMILY);
+        options.put("value.format", "json");
+        options.put(BigtableConnectorOptions.QUALIFIER_FIELD.key(), TestingUtils.ROW_KEY_FIELD);
+
+        ResolvedSchema schema = getResolvedSchema(false);
+
+        Assertions.assertThatThrownBy(() -> FactoryMocks.createTableSink(schema, options))
+                .hasStackTraceContaining(
+                        "qualifier-field cannot be the same as the primary key field");
+    }
+
+    @Test
     public void testQualifierFieldNotInSchemaThrows() {
         Map<String, String> options = getRequiredOptions();
         options.put(BigtableConnectorOptions.COLUMN_FAMILY.key(), TestingUtils.COLUMN_FAMILY);


### PR DESCRIPTION
## Summary

Add `FormatAwareRowMutationSerializer` that delegates cell value encoding to any Flink-compatible format (JSON, Protobuf, Avro, etc.) via the `SerializationFormatFactory` SPI.

This allows users to leverage Flink's ecosystem of format plugins instead of being limited to the connector's built-in byte serialization, while preserving Bigtable's cell-level data model (per-column reads, filters, TTL).

### New Table API Options

  | Option | Description |
  |---|---|
  | `value.format` | Selects the encoding format (e.g., `protobuf`, `json`, `avro`) |
  | `qualifier-field` | Uses a field value as the column qualifier (flat mode) |
  | `<family>.qualifier-field` | Per-family qualifier field (nested-rows mode) |

  ### Modes

  - **Flat mode**: Single column family with `value.format` + optional `qualifier-field`
  - **Nested rows mode**: Multiple column families with `value.format` + optional `<family>.qualifier-field`
  - **Legacy mode**: No `value.format` set - existing built-in serialization is unchanged

### Backward Compatibility

No breaking changes. When `value.format` is not set, the connector behaves exactly as before.

### Test Coverage
- `FormatAwareRowMutationSerializerTest` — unit tests for flat mode, nested-rows mode, qualifier-field, upsert/delete handling
- `QualifierConfigTest` — qualifier field resolution
- `BigtableTableTest` — end-to-end Table API integration tests with format discovery
